### PR TITLE
Arduino exe now found on windows

### DIFF
--- a/SampleProjects/DoSomething/.arduino-ci.yaml
+++ b/SampleProjects/DoSomething/.arduino-ci.yaml
@@ -11,3 +11,5 @@ unittest:
     - uno
     - due
     - leonardo
+  compilers:
+    - g++

--- a/SampleProjects/DoSomething/Gemfile.lock
+++ b/SampleProjects/DoSomething/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: /Users/ikatz/Development/non-wayfair/arduino_ci
+  remote: ../..
   specs:
-    arduino_ci (0.1.7)
+    arduino_ci (0.1.9)
       os (~> 1.0)
 
 GEM
@@ -11,9 +11,10 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   arduino_ci!
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/lib/arduino_ci/arduino_downloader.rb
+++ b/lib/arduino_ci/arduino_downloader.rb
@@ -87,7 +87,7 @@ module ArduinoCI
     # The URL of the desired IDE package (zip/tar/etc) for this platform
     # @return [string]
     def package_url
-      "http://downloads.arduino.cc/#{package_file}"
+      "https://downloads.arduino.cc/#{package_file}"
     end
 
     # The local file (dir) name of the desired IDE package (zip/tar/etc)

--- a/lib/arduino_ci/arduino_downloader.rb
+++ b/lib/arduino_ci/arduino_downloader.rb
@@ -87,7 +87,7 @@ module ArduinoCI
     # The URL of the desired IDE package (zip/tar/etc) for this platform
     # @return [string]
     def package_url
-      "https://downloads.arduino.cc/#{package_file}"
+      "http://downloads.arduino.cc/#{package_file}"
     end
 
     # The local file (dir) name of the desired IDE package (zip/tar/etc)

--- a/lib/arduino_ci/arduino_downloader_windows.rb
+++ b/lib/arduino_ci/arduino_downloader_windows.rb
@@ -78,7 +78,7 @@ module ArduinoCI
     # The executable Arduino file in an existing installation, or nil
     # @return [string]
     def self.existing_executable
-      arduino_reg = 'SOFTWARE\WOW6432Node\Arduino1'
+      arduino_reg = 'SOFTWARE\WOW6432Node\Arduino'
       Win32::Registry::HKEY_LOCAL_MACHINE.open(arduino_reg) do |reg|
         path = reg.read_s('Install_Dir')
         puts 'Arduino Install Dir: ' + path

--- a/lib/arduino_ci/arduino_downloader_windows.rb
+++ b/lib/arduino_ci/arduino_downloader_windows.rb
@@ -85,7 +85,7 @@ module ArduinoCI
         exe = File.join(path, "arduino_debug.exe")
         return exe if File.exist? exe
       end
-      rescue
+    rescue
       nil
     end
 

--- a/lib/arduino_ci/arduino_downloader_windows.rb
+++ b/lib/arduino_ci/arduino_downloader_windows.rb
@@ -79,14 +79,14 @@ module ArduinoCI
     # @return [string]
     def self.existing_executable
       arduino_reg = 'SOFTWARE\WOW6432Node\Arduino'
-      Win32::Registry::HKEY_LOCAL_MACHINE.open(arduino_reg) do |reg| 
-      path = reg.read_s('Install_Dir') 
+      Win32::Registry::HKEY_LOCAL_MACHINE.open(arduino_reg) do |reg|
+      path = reg.read_s('Install_Dir')
       puts 'Arduino Install Dir: ' + path
       exe = File.join(path, "arduino.exe")
       return exe if File.exist? exe
-    end
+      end
     nil
-  end
+    end
 
     # The executable Arduino file in a forced installation, or nil
     # @return [string]

--- a/lib/arduino_ci/arduino_downloader_windows.rb
+++ b/lib/arduino_ci/arduino_downloader_windows.rb
@@ -74,24 +74,19 @@ module ArduinoCI
       return nil if exe.nil?
       File.dirname(exe)
     end
-
+     
     # The executable Arduino file in an existing installation, or nil
     # @return [string]
     def self.existing_executable
-      arduino_reg = 'Software\SOFTWARE\Classes\Arduino file\shell\open\command'
-      Win32::Registry::HKEY_LOCAL_MACHINE.open(arduino_reg) do |reg|
-        reg.each_key do |key|
-          k = reg.open(key)
-          puts key
-          puts k
-          return k
-          # puts k["DisplayName"]    rescue "?"
-          # puts k["DisplayVersion"] rescue "?"
-          # puts
-        end
-      end
-      nil
+      arduino_reg = 'SOFTWARE\WOW6432Node\Arduino'
+      Win32::Registry::HKEY_LOCAL_MACHINE.open(arduino_reg) do |reg| 
+      path = reg.read_s('Install_Dir') 
+      puts 'Arduino Install Dir: ' + path
+      exe = File.join(path, "arduino.exe")
+      return exe if File.exist? exe
     end
+    nil
+  end
 
     # The executable Arduino file in a forced installation, or nil
     # @return [string]

--- a/lib/arduino_ci/arduino_downloader_windows.rb
+++ b/lib/arduino_ci/arduino_downloader_windows.rb
@@ -78,17 +78,15 @@ module ArduinoCI
     # The executable Arduino file in an existing installation, or nil
     # @return [string]
     def self.existing_executable
-      begin
-        arduino_reg = 'SOFTWARE\WOW6432Node\Arduino1'
-        Win32::Registry::HKEY_LOCAL_MACHINE.open(arduino_reg) do |reg|
-          path = reg.read_s('Install_Dir')
-          puts 'Arduino Install Dir: ' + path
-          exe = File.join(path, "arduino_debug.exe")
-          return exe if File.exist? exe
-        end
-      rescue
-        nil
+      arduino_reg = 'SOFTWARE\WOW6432Node\Arduino1'
+      Win32::Registry::HKEY_LOCAL_MACHINE.open(arduino_reg) do |reg|
+        path = reg.read_s('Install_Dir')
+        puts 'Arduino Install Dir: ' + path
+        exe = File.join(path, "arduino_debug.exe")
+        return exe if File.exist? exe
       end
+      rescue
+      nil
     end
 
     # The executable Arduino file in a forced installation, or nil

--- a/lib/arduino_ci/arduino_downloader_windows.rb
+++ b/lib/arduino_ci/arduino_downloader_windows.rb
@@ -35,8 +35,8 @@ module ArduinoCI
     # @return [bool] whether successful
     def download
       puts 'Downloading from ' + package_url
-      # Turned off ssl verification 
-      open(URI.parse(package_url), {ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE}) do |url|
+      # Turned off ssl verification
+      open(URI.parse(package_url), ssl_verify_mode: 0) do |url|
         File.open(package_file, 'wb') { |file| file.write(url.read) }
       end
     end

--- a/lib/arduino_ci/arduino_downloader_windows.rb
+++ b/lib/arduino_ci/arduino_downloader_windows.rb
@@ -35,7 +35,8 @@ module ArduinoCI
     # @return [bool] whether successful
     def download
       puts 'Downloading from ' + package_url
-      open(URI.parse(package_url)) do |url|
+      # Turned off ssl verification 
+      open(URI.parse(package_url), {ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE}) do |url|
         File.open(package_file, 'wb') { |file| file.write(url.read) }
       end
     end

--- a/lib/arduino_ci/arduino_downloader_windows.rb
+++ b/lib/arduino_ci/arduino_downloader_windows.rb
@@ -91,7 +91,7 @@ module ArduinoCI
     # The executable Arduino file in an existing installation, or nil
     # @return [string]
     def self.existing_executable
-      arduino_reg = 'SOFTWARE\WOW6432Node\Arduino1'
+      arduino_reg = 'SOFTWARE\WOW6432Node\Arduino'
       Win32::Registry::HKEY_LOCAL_MACHINE.open(arduino_reg) do |reg|
         path = reg.read_s('Install_Dir')
         exe = File.join(path, "arduino_debug.exe")
@@ -106,7 +106,7 @@ module ArduinoCI
     # @return [string]
     def self.force_installed_executable
       exe = File.join(self.force_install_location, "arduino_debug.exe")
-      puts "using force installed exe located at " + exe
+      puts "Using force installed exe located at " + exe
       return nil if exe.nil?
       exe
     end

--- a/lib/arduino_ci/arduino_downloader_windows.rb
+++ b/lib/arduino_ci/arduino_downloader_windows.rb
@@ -78,20 +78,23 @@ module ArduinoCI
     # The executable Arduino file in an existing installation, or nil
     # @return [string]
     def self.existing_executable
-      arduino_reg = 'SOFTWARE\WOW6432Node\Arduino'
-      Win32::Registry::HKEY_LOCAL_MACHINE.open(arduino_reg) do |reg|
-        path = reg.read_s('Install_Dir')
-        puts 'Arduino Install Dir: ' + path
-        exe = File.join(path, "arduino_debug.exe")
-        return exe if File.exist? exe
+      begin
+        arduino_reg = 'SOFTWARE\WOW6432Node\Arduino1'
+        Win32::Registry::HKEY_LOCAL_MACHINE.open(arduino_reg) do |reg|
+          path = reg.read_s('Install_Dir')
+          puts 'Arduino Install Dir: ' + path
+          exe = File.join(path, "arduino_debug.exe")
+          return exe if File.exist? exe
+        end
+      rescue
+        nil
       end
-      nil
     end
 
     # The executable Arduino file in a forced installation, or nil
     # @return [string]
     def self.force_installed_executable
-      exe = File.join(self.force_install_location, "arduino.exe")
+      exe = File.join(self.force_install_location, "arduino_debug.exe")
       return nil if exe.nil?
       exe
     end

--- a/lib/arduino_ci/arduino_downloader_windows.rb
+++ b/lib/arduino_ci/arduino_downloader_windows.rb
@@ -82,7 +82,7 @@ module ArduinoCI
       Win32::Registry::HKEY_LOCAL_MACHINE.open(arduino_reg) do |reg|
         path = reg.read_s('Install_Dir')
         puts 'Arduino Install Dir: ' + path
-        exe = File.join(path, "arduino.exe")
+        exe = File.join(path, "arduino_debug.exe")
         return exe if File.exist? exe
       end
       nil

--- a/lib/arduino_ci/arduino_downloader_windows.rb
+++ b/lib/arduino_ci/arduino_downloader_windows.rb
@@ -80,12 +80,12 @@ module ArduinoCI
     def self.existing_executable
       arduino_reg = 'SOFTWARE\WOW6432Node\Arduino'
       Win32::Registry::HKEY_LOCAL_MACHINE.open(arduino_reg) do |reg|
-      path = reg.read_s('Install_Dir')
-      puts 'Arduino Install Dir: ' + path
-      exe = File.join(path, "arduino.exe")
-      return exe if File.exist? exe
+        path = reg.read_s('Install_Dir')
+        puts 'Arduino Install Dir: ' + path
+        exe = File.join(path, "arduino.exe")
+        return exe if File.exist? exe
       end
-    nil
+      nil
     end
 
     # The executable Arduino file in a forced installation, or nil

--- a/lib/arduino_ci/arduino_downloader_windows.rb
+++ b/lib/arduino_ci/arduino_downloader_windows.rb
@@ -74,7 +74,7 @@ module ArduinoCI
       return nil if exe.nil?
       File.dirname(exe)
     end
-     
+
     # The executable Arduino file in an existing installation, or nil
     # @return [string]
     def self.existing_executable

--- a/lib/arduino_ci/arduino_installation.rb
+++ b/lib/arduino_ci/arduino_installation.rb
@@ -96,7 +96,7 @@ module ArduinoCI
       def force_install
         worker_class =  case Host.os
                         when :osx then ArduinoDownloaderOSX
-                        # when :windows then force_install_windows
+                        when :windows then ArduinoDownloaderWindows
                         when :linux then ArduinoDownloaderLinux
                         end
         worker = worker_class.new(DESIRED_ARDUINO_IDE_VERSION)


### PR DESCRIPTION
Changes:
* Updated arduino self.existing_executable function to find exe
* Added compilers to .arduino-ci.yaml so that build runs

With the updated code and g++ on the path the DoSomething example appears to run as as expected.

It is a bit clunky because the ide splash pops up all the time, can this be supressed? I guess not as the the comand line docs [here](https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc) don't seem to mention it.