### PR TITLE
More mocks and bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Explicit checks that the requested test platforms are defined in YML
+- Method to guess whether a library is installed
 
 ### Changed
 - Refactored documentation
+- External libraries aren't forcibly installed via the Arduino binary (in `arduino_cmd_remote.rb`) if they appear to exist on disk already
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Arduino command wrapper can now guess whether a library is installed
 - CPP library class now reaches into included Arduino libraries for source files
 - SPI mocks
+- `ensure_arduino_installation.rb` to allow custom libraries to be installed
 
 ### Changed
 - Refactored documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Explicit checks that the requested test platforms are defined in YML
 - Arduino command wrapper can now guess whether a library is installed
 - CPP library class now reaches into included Arduino libraries for source files
+- SPI mocks
 
 ### Changed
 - Refactored documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Refactored documentation
 - External libraries aren't forcibly installed via the Arduino binary (in `arduino_cmd_remote.rb`) if they appear to exist on disk already
+- `attachInterrupt` and `detachInterrupt` are now mocked instead of `_NOP`
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Explicit checks that the requested test platforms are defined in YML
 
 ### Changed
 - Refactored documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Explicit checks that the requested test platforms are defined in YML
-- Method to guess whether a library is installed
+- Arduino command wrapper can now guess whether a library is installed
+- CPP library class now reaches into included Arduino libraries for source files
 
 ### Changed
 - Refactored documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Display Manager became no longer necessary with Arduino 1.8.X
 
 ### Fixed
+- OSX splash screen re-disabled
 
 ### Security
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -366,3 +366,43 @@ unittest(interrupt_attachment) {
   detachInterrupt(7);
   assertFalse(state->interrupt[7].attached);
 }```
+
+
+### SPI
+
+These basic mocks of SPI store the values in Strings.
+
+```C++
+unittest(spi) {
+  GodmodeState *state = GODMODE();
+
+  // 8-bit
+  state->reset();
+  state->spi.dataIn = "LMNO";
+  uint8_t out8 = SPI.transfer('a');
+  assertEqual("a", state->spi.dataOut);
+  assertEqual('L', out8);
+  assertEqual("MNO", state->spi.dataIn);
+
+  // 16-bit
+  union { uint16_t val; struct { char lsb; char msb; }; } in16, out16;
+  state->reset();
+  state->spi.dataIn = "LMNO";
+  in16.lsb = 'a';
+  in16.msb = 'b';
+  out16.val = SPI.transfer16(in16.val);
+  assertEqual("NO", state->spi.dataIn);
+  assertEqual('L', out16.lsb);
+  assertEqual('M', out16.msb);
+  assertEqual("ab", state->spi.dataOut);
+
+  // buffer
+  state->reset();
+  state->spi.dataIn = "LMNOP";
+  char inBuf[6] = "abcde";
+  SPI.transfer(inBuf, 4);
+
+  assertEqual("abcd", state->spi.dataOut);
+  assertEqual("LMNOe", String(inBuf));
+}
+```

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -351,3 +351,18 @@ unittest(modem_hardware)
 Note that instead of setting `mLast = output` in the `onMatchInput()` function for test purposes, we could just as easily queue some bytes to state->serialPort[0].dataIn for the library under test to find on its next `peek()` or `read()`.  Or we could execute some action on a digital or analog input pin; the possibilities are fairly endless in this regard, although you will have to define them yourself -- from scratch -- extending the `DataStreamObserver` class to emulate your physical device.
 
 
+### Interrupts
+
+Although ISRs should be tested directly (as their asynchronous nature is not mocked), the act of attaching or detaching an interrupt can be measured.
+
+```C++
+unittest(interrupt_attachment) {
+  GodmodeState *state = GODMODE();
+  state->reset();
+  assertFalse(state->interrupt[7].attached);
+  attachInterrupt(7, (void (*)(void))0, 3);
+  assertTrue(state->interrupt[7].attached);
+  assertEqual(state->interrupt[7].mode, 3);
+  detachInterrupt(7);
+  assertFalse(state->interrupt[7].attached);
+}```

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -100,6 +100,42 @@ unittest_main()
 This test defines one `unittest` (a macro provided by `ArduinoUnitTests.h`), called `your_test_name`, which makes some assertions on the target library.  The `unittest_main()` is a macro for the `int main()` boilerplate required for unit testing.
 
 
+# Build Scripts
+
+For most build environments, the only script that need be executed by the CI system is
+
+```shell
+# simplest build script
+bundle install
+bundle exec arduino_ci_remote.rb
+```
+
+However, more flexible usage is available:
+
+### Custom Versions of external Arduino Libraries
+
+Sometimes you need a fork of an Arduino library instead of the version that will be installed via their GUI.  `arduino_ci_remote.rb` won't overwrite existing downloaded libraries with fresh downloads, but it won't fetch the custom versions for you either.
+
+If this is the behavior you need, `ensure_arduino_installation.rb` is for you.
+
+```shell
+# Example build script
+bundle install
+
+# ensure the Arduino installation -- creates the Library directory
+bundle exec ensure_arduino_installation.rb
+
+# manually install the custom version you need
+git clone https://repository.com/custom_library_repo.git
+mv custom_library_repo /path/to/Arduino/libraries
+
+# now run CI
+bundle exec arduino_ci_remote.rb
+```
+
+
+
+
 # Mocks
 
 ## Using `GODMODE`

--- a/SampleProjects/TestSomething/test/godmode.cpp
+++ b/SampleProjects/TestSomething/test/godmode.cpp
@@ -172,6 +172,17 @@ unittest(pin_write_history)
 
 }
 
+unittest(interrupt_attachment) {
+  GodmodeState *state = GODMODE();
+  state->reset();
+  assertFalse(state->interrupt[0].attached);
+  attachInterrupt(0, (void (*)(void))0, 3);
+  assertTrue(state->interrupt[0].attached);
+  assertEqual(state->interrupt[0].mode, 3);
+  detachInterrupt(0);
+  assertFalse(state->interrupt[0].attached);
+}
+
 #ifdef HAVE_HWSERIAL0
 
   void smartLightswitchSerialHandler(int pin) {

--- a/cpp/arduino/Arduino.h
+++ b/cpp/arduino/Arduino.h
@@ -43,9 +43,6 @@ typedef uint8_t byte;
 #define yield() _NOP()
 #define interrupts() _NOP()
 #define noInterrupts() _NOP()
-#define attachInterrupt(...) _NOP()
-#define detachInterrupt(...) _NOP()
-
 
 // TODO: correctly establish this per-board!
 #define F_CPU 1000000UL

--- a/cpp/arduino/Arduino.h
+++ b/cpp/arduino/Arduino.h
@@ -14,6 +14,7 @@ Where possible, variable names from the Arduino library are used to avoid confli
 #include "Print.h"
 #include "Stream.h"
 #include "HardwareSerial.h"
+#include "SPI.h"
 
 typedef bool boolean;
 typedef uint8_t byte;

--- a/cpp/arduino/Godmode.cpp
+++ b/cpp/arduino/Godmode.cpp
@@ -67,6 +67,16 @@ int analogRead(unsigned char pin) {
   return godmode->analogPin[pin].retrieve();
 }
 
+void attachInterrupt(uint8_t interrupt, void ISR(void), uint8_t mode) {
+  GodmodeState* godmode = GODMODE();
+  godmode->interrupt[interrupt].attached = true;
+  godmode->interrupt[interrupt].mode = mode;
+}
+
+void detachInterrupt(uint8_t interrupt) {
+  GodmodeState* godmode = GODMODE();
+  godmode->interrupt[interrupt].attached = false;
+}
 
 // Serial ports
 #if defined(HAVE_HWSERIAL0)

--- a/cpp/arduino/Godmode.cpp
+++ b/cpp/arduino/Godmode.cpp
@@ -1,5 +1,6 @@
 #include "Godmode.h"
 #include "HardwareSerial.h"
+#include "SPI.h"
 
 GodmodeState godmode = GodmodeState();
 
@@ -97,3 +98,6 @@ inline std::ostream& operator << ( std::ostream& out, const PinHistory<T>& ph ) 
   out << ph;
   return out;
 }
+
+// defined in SPI.h
+SPIClass SPI = SPIClass(&godmode.spi.dataIn, &godmode.spi.dataOut);

--- a/cpp/arduino/Godmode.h
+++ b/cpp/arduino/Godmode.h
@@ -51,6 +51,7 @@ class GodmodeState {
     PinHistory<int> analogPin[MOCK_PINS_COUNT];
     struct PortDef serialPort[NUM_SERIAL_PORTS];
     struct InterruptDef interrupt[MOCK_PINS_COUNT]; // not sure how to get actual number
+    struct PortDef spi;
 
     void resetPins() {
       for (int i = 0; i < MOCK_PINS_COUNT; ++i) {
@@ -69,10 +70,27 @@ class GodmodeState {
       }
     }
 
+    void resetPorts() {
+      for (int i = 0; i < serialPorts(); ++i)
+      {
+        serialPort[i].dataIn = "";
+        serialPort[i].dataOut = "";
+        serialPort[i].readDelayMicros = 0;
+      }
+    }
+
+    void resetSPI() {
+      spi.dataIn = "";
+      spi.dataOut = "";
+      spi.readDelayMicros = 0;
+    }
+
     void reset() {
       resetClock();
       resetPins();
       resetInterrupts();
+      resetPorts();
+      resetSPI();
       seed = 1;
     }
 
@@ -83,14 +101,7 @@ class GodmodeState {
     GodmodeState()
     {
       reset();
-      for (int i = 0; i < serialPorts(); ++i)
-      {
-        serialPort[i].dataIn = "";
-        serialPort[i].dataOut = "";
-        serialPort[i].readDelayMicros = 0;
-      }
-  }
-
+    }
 };
 
 // io pins

--- a/cpp/arduino/Godmode.h
+++ b/cpp/arduino/Godmode.h
@@ -38,6 +38,11 @@ class GodmodeState {
     unsigned long readDelayMicros;
   };
 
+  struct InterruptDef {
+    bool attached;
+    uint8_t mode;
+  };
+
   public:
     unsigned long micros;
     unsigned long seed;
@@ -45,6 +50,7 @@ class GodmodeState {
     PinHistory<bool> digitalPin[MOCK_PINS_COUNT];
     PinHistory<int> analogPin[MOCK_PINS_COUNT];
     struct PortDef serialPort[NUM_SERIAL_PORTS];
+    struct InterruptDef interrupt[MOCK_PINS_COUNT]; // not sure how to get actual number
 
     void resetPins() {
       for (int i = 0; i < MOCK_PINS_COUNT; ++i) {
@@ -57,9 +63,16 @@ class GodmodeState {
       micros = 0;
     }
 
+    void resetInterrupts() {
+      for (int i = 0; i < MOCK_PINS_COUNT; ++i) {
+        interrupt[i].attached = false;
+      }
+    }
+
     void reset() {
       resetClock();
       resetPins();
+      resetInterrupts();
       seed = 1;
     }
 
@@ -90,6 +103,8 @@ int analogRead(uint8_t);
 void analogWrite(uint8_t, int);
 #define analogReadResolution(...) _NOP()
 #define analogWriteResolution(...) _NOP()
+void attachInterrupt(uint8_t interrupt, void ISR(void), uint8_t mode);
+void detachInterrupt(uint8_t interrupt);
 
 // TODO: issue #26 to track the commanded state here
 inline void tone(uint8_t _pin, unsigned int frequency, unsigned long duration = 0) {}

--- a/cpp/arduino/SPI.h
+++ b/cpp/arduino/SPI.h
@@ -1,0 +1,150 @@
+#pragma once
+
+#include "Stream.h"
+
+// defines from original file
+#define _SPI_H_INCLUDED
+#define SPI_HAS_TRANSACTION 1
+#define SPI_HAS_NOTUSINGINTERRUPT 1
+#define SPI_ATOMIC_VERSION 1
+#define SPI_CLOCK_DIV4 0x00
+#define SPI_CLOCK_DIV16 0x01
+#define SPI_CLOCK_DIV64 0x02
+#define SPI_CLOCK_DIV128 0x03
+#define SPI_CLOCK_DIV2 0x04
+#define SPI_CLOCK_DIV8 0x05
+#define SPI_CLOCK_DIV32 0x06
+#define SPI_MODE0 0x00
+#define SPI_MODE1 0x04
+#define SPI_MODE2 0x08
+#define SPI_MODE3 0x0C
+#define SPI_MODE_MASK 0x0C
+#define SPI_CLOCK_MASK 0x03
+#define SPI_2XCLOCK_MASK 0x01
+
+#ifndef LSBFIRST
+#define LSBFIRST 0
+#endif
+#ifndef MSBFIRST
+#define MSBFIRST 1
+#endif
+
+#if defined(EIMSK)
+  #define SPI_AVR_EIMSK  EIMSK
+#elif defined(GICR)
+  #define SPI_AVR_EIMSK  GICR
+#elif defined(GIMSK)
+  #define SPI_AVR_EIMSK  GIMSK
+#endif
+
+
+class SPISettings {
+public:
+  SPISettings(uint32_t clock, uint8_t bitOrder, uint8_t dataMode){};
+  SPISettings(){};
+};
+
+
+class SPIClass: public ObservableDataStream {
+public:
+
+  SPIClass(String* dataIn, String* dataOut) {
+    this->dataIn = dataIn;
+    this->dataOut = dataOut;
+  }
+
+  // Initialize the SPI library
+  void begin() { isStarted = true; }
+
+  // Disable the SPI bus
+  void end() { isStarted = false; }
+
+  // this has no tangible effect in a mocked Arduino
+  void usingInterrupt(uint8_t interruptNumber){}
+  void notUsingInterrupt(uint8_t interruptNumber){}
+
+  // Before using SPI.transfer() or asserting chip select pins,
+  // this function is used to gain exclusive access to the SPI bus
+  // and configure the correct settings.
+  void beginTransaction(SPISettings settings)
+  {
+    #ifdef SPI_TRANSACTION_MISMATCH_LED
+    if (inTransactionFlag) {
+      pinMode(SPI_TRANSACTION_MISMATCH_LED, OUTPUT);
+      digitalWrite(SPI_TRANSACTION_MISMATCH_LED, HIGH);
+    }
+    inTransactionFlag = 1;
+    #endif
+  }
+
+  // Write to the SPI bus (MOSI pin) and also receive (MISO pin)
+  uint8_t transfer(uint8_t data) {
+    //FIXME!
+    // push memory->bus
+    dataOut->append(String((char)data));
+    advertiseByte((char)data);
+
+    // pop bus->memory data from its queue and return it
+    if (!dataIn->length()) return 0;
+    char ret = (*dataIn)[0];
+    *dataIn = dataIn->substr(1, dataIn->length());
+    return ret;
+  }
+
+  uint16_t transfer16(uint16_t data) {
+    union { uint16_t val; struct { uint8_t lsb; uint8_t msb; }; } in, out;
+    in.val = data;
+    if (!(SPCR & (1 << DORD))) {
+      out.msb = transfer(in.msb);
+      out.lsb =  transfer(in.lsb);
+    } else {
+      out.lsb =  transfer(in.lsb);
+      out.msb = transfer(in.msb);
+    }
+    return out.val;
+  }
+
+  void transfer(void *buf, size_t count) {
+    // TODO: this logic is rewritten from the original,
+    // I'm not sure what role the SPDR register (which I removed) plays
+
+    uint8_t *p = (uint8_t *)buf;
+    for (int i = 0; i < count; ++i) {
+      *(p + i) = transfer(*(p + i));
+    }
+  }
+
+  // After performing a group of transfers and releasing the chip select
+  // signal, this function allows others to access the SPI bus
+  void endTransaction(void) {
+    #ifdef SPI_TRANSACTION_MISMATCH_LED
+    if (!inTransactionFlag) {
+      pinMode(SPI_TRANSACTION_MISMATCH_LED, OUTPUT);
+      digitalWrite(SPI_TRANSACTION_MISMATCH_LED, HIGH);
+    }
+    inTransactionFlag = 0;
+    #endif
+  }
+
+  // deprecated functions, skip 'em
+  void setBitOrder(uint8_t bitOrder){}
+  void setDataMode(uint8_t dataMode){}
+  void setClockDivider(uint8_t clockDiv){}
+  void attachInterrupt(){}
+  void detachInterrupt(){}
+
+private:
+  uint8_t initialized;   // initialized in Godmode.cpp
+  uint8_t interruptMode; // 0=none, 1=mask, 2=global
+  uint8_t interruptMask; // which interrupts to mask
+  uint8_t interruptSave; // temp storage, to restore state
+  #ifdef SPI_TRANSACTION_MISMATCH_LED
+  uint8_t inTransactionFlag;
+  #endif
+
+  bool isStarted = false;
+  String* dataIn;
+  String* dataOut;
+};
+
+extern SPIClass SPI;

--- a/exe/arduino_ci_remote.rb
+++ b/exe/arduino_ci_remote.rb
@@ -119,7 +119,11 @@ all_packages.each do |p|
 end
 
 aux_libraries.each do |l|
-  assure("Installing aux library '#{l}'") { @arduino_cmd.install_library(l) }
+  if @arduino_cmd.library_present?(l)
+    assure("Using pre-existing library '#{l}'") { true }
+  else
+    assure("Installing aux library '#{l}'") { @arduino_cmd.install_library(l) }
+  end
 end
 
 # iterate boards / tests

--- a/exe/arduino_ci_remote.rb
+++ b/exe/arduino_ci_remote.rb
@@ -74,7 +74,7 @@ config = ArduinoCI::CIConfig.default.from_project_library
 # initialize library under test
 installed_library_path = assure("Installing library under test") { @arduino_cmd.install_local_library(".") }
 library_examples = @arduino_cmd.library_examples(installed_library_path)
-cpp_library = ArduinoCI::CppLibrary.new(installed_library_path)
+cpp_library = ArduinoCI::CppLibrary.new(installed_library_path, @arduino_cmd.lib_dir)
 attempt("Library installed at #{installed_library_path}") { true }
 
 # check GCC

--- a/exe/ensure_arduino_installation.rb
+++ b/exe/ensure_arduino_installation.rb
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+require 'arduino_ci'
+
+# this will exit after Arduino is located and/or forcibly installed
+ArduinoCI::ArduinoInstallation.autolocate!

--- a/lib/arduino_ci/arduino_cmd.rb
+++ b/lib/arduino_ci/arduino_cmd.rb
@@ -193,6 +193,17 @@ module ArduinoCI
       File.join(_lib_dir, library_name)
     end
 
+    # Determine whether a library is present in the lib dir
+    #
+    # Note that `true` doesn't guarantee that the library is valid/installed
+    #  and `false` doesn't guarantee that the library isn't built-in
+    #
+    # @param library_name [String] The name of the library
+    # @return [bool]
+    def library_present?(library_name)
+      File.exist?(library_path(library_name))
+    end
+
     # update the library index
     # @return [bool] Whether the update succeeded
     def update_library_index

--- a/lib/arduino_ci/arduino_cmd.rb
+++ b/lib/arduino_ci/arduino_cmd.rb
@@ -66,8 +66,8 @@ module ArduinoCI
     end
 
     # @return [String] the path to the Arduino libraries directory
-    def _lib_dir
-      "<lib dir not defined>"
+    def lib_dir
+      "<lib_dir not defined>"
     end
 
     # fetch preferences in their raw form
@@ -190,7 +190,7 @@ module ArduinoCI
     # @param library_name [String] The name of the library
     # @return [String] The fully qualified library name
     def library_path(library_name)
-      File.join(_lib_dir, library_name)
+      File.join(lib_dir, library_name)
     end
 
     # Determine whether a library is present in the lib dir

--- a/lib/arduino_ci/arduino_cmd_linux.rb
+++ b/lib/arduino_ci/arduino_cmd_linux.rb
@@ -33,7 +33,7 @@ module ArduinoCI
 
     # implementation for Arduino library dir location
     # @return [String] the path to the Arduino libraries directory
-    def _lib_dir
+    def lib_dir
       File.join(get_pref("sketchbook.path"), "libraries")
     end
 

--- a/lib/arduino_ci/arduino_cmd_linux_builder.rb
+++ b/lib/arduino_ci/arduino_cmd_linux_builder.rb
@@ -16,7 +16,7 @@ module ArduinoCI
 
     # linux-specific implementation
     # @return [String] The path to the library dir
-    def _lib_dir
+    def lib_dir
       File.join(get_pref("sketchbook.path"), "libraries")
     end
 

--- a/lib/arduino_ci/arduino_cmd_osx.rb
+++ b/lib/arduino_ci/arduino_cmd_osx.rb
@@ -13,7 +13,7 @@ module ArduinoCI
     flag :install_library, "--install-library"
     flag :verify,          "--verify"
 
-    def _lib_dir
+    def lib_dir
       File.join(ENV['HOME'], "Documents", "Arduino", "libraries")
     end
 

--- a/lib/arduino_ci/arduino_cmd_windows.rb
+++ b/lib/arduino_ci/arduino_cmd_windows.rb
@@ -13,7 +13,7 @@ module ArduinoCI
     flag :install_library, "--install-library"
     flag :verify,          "--verify"
 
-    def _lib_dir
+    def lib_dir
       File.join(ENV['userprofile'], "Documents", "Arduino", "libraries")
     end
 

--- a/lib/arduino_ci/arduino_installation.rb
+++ b/lib/arduino_ci/arduino_installation.rb
@@ -51,8 +51,9 @@ module ArduinoCI
           # from https://github.com/arduino/Arduino/issues/1970#issuecomment-321975809
           [
             "java",
-            "-cp", "#{osx_root}/Java/*",
-            "-DAPP_DIR=#{osx_root}/Java",
+            "-cp",
+            "#{osx_root}/Contents/Java/*",
+            "-DAPP_DIR=#{osx_root}/Contents/Java",
             "-Dfile.encoding=UTF-8",
             "-Dapple.awt.UIElement=true",
             "-Xms128M",

--- a/spec/arduino_cmd_spec.rb
+++ b/spec/arduino_cmd_spec.rb
@@ -46,6 +46,15 @@ RSpec.describe ArduinoCI::ArduinoCmd do
     end
   end
 
+  context "libraries" do
+    it "knows where to find libraries" do
+      fake_lib = "_____nope"
+      expected_dir = File.join(arduino_cmd._lib_dir, fake_lib)
+      expect(arduino_cmd.library_path(fake_lib)).to eq(expected_dir)
+      expect(arduino_cmd.library_present?(fake_lib)).to be false
+    end
+  end
+
   context "set_pref" do
 
     it "Sets key to what it was before" do

--- a/spec/arduino_cmd_spec.rb
+++ b/spec/arduino_cmd_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ArduinoCI::ArduinoCmd do
   context "libraries" do
     it "knows where to find libraries" do
       fake_lib = "_____nope"
-      expected_dir = File.join(arduino_cmd._lib_dir, fake_lib)
+      expected_dir = File.join(arduino_cmd.lib_dir, fake_lib)
       expect(arduino_cmd.library_path(fake_lib)).to eq(expected_dir)
       expect(arduino_cmd.library_present?(fake_lib)).to be false
     end

--- a/spec/arduino_installation_spec.rb
+++ b/spec/arduino_installation_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ArduinoCI::ArduinoInstallation do
     arduino_cmd = ArduinoCI::ArduinoInstallation.autolocate!
     it "doesn't fail" do
       expect(arduino_cmd.base_cmd).not_to be nil
-      expect(arduino_cmd._lib_dir).not_to be nil
+      expect(arduino_cmd.lib_dir).not_to be nil
     end
   end
 

--- a/spec/ci_config_spec.rb
+++ b/spec/ci_config_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe ArduinoCI::CIConfig do
 
   context "allowable_unittest_files" do
     cpp_lib_path = File.join(File.dirname(__FILE__), "fake_library")
-    cpp_library = ArduinoCI::CppLibrary.new(cpp_lib_path)
+    cpp_library = ArduinoCI::CppLibrary.new(cpp_lib_path, "my_fake_arduino_lib_dir")
 
     it "starts with a known set of files" do
       expect(cpp_library.test_files.map { |f| File.basename(f) }).to match_array([

--- a/spec/cpp_library_spec.rb
+++ b/spec/cpp_library_spec.rb
@@ -4,7 +4,7 @@ sampleproj_path = File.join(File.dirname(File.dirname(__FILE__)), "SampleProject
 
 RSpec.describe ArduinoCI::CppLibrary do
   cpp_lib_path = File.join(sampleproj_path, "DoSomething")
-  cpp_library = ArduinoCI::CppLibrary.new(cpp_lib_path)
+  cpp_library = ArduinoCI::CppLibrary.new(cpp_lib_path, "my_fake_arduino_lib_dir")
   context "cpp_files" do
     it "finds cpp files in directory" do
       dosomething_cpp_files = ["DoSomething/do-something.cpp"]

--- a/spec/testsomething_unittests_spec.rb
+++ b/spec/testsomething_unittests_spec.rb
@@ -4,7 +4,7 @@ sampleproj_path = File.join(File.dirname(File.dirname(__FILE__)), "SampleProject
 
 RSpec.describe "TestSomething C++" do
   cpp_lib_path = File.join(sampleproj_path, "TestSomething")
-  cpp_library = ArduinoCI::CppLibrary.new(cpp_lib_path)
+  cpp_library = ArduinoCI::CppLibrary.new(cpp_lib_path, "my_fake_arduino_lib_dir")
   context "cpp_files" do
     it "finds cpp files in directory" do
       testsomething_cpp_files = ["TestSomething/test-something.cpp"]


### PR DESCRIPTION
## Highlights from `CHANGELOG.md`

* Mock SPI
* Don't overwrite existing library directories with new downloads
* Properly pull in source files from external libraries (I think)
* Add `ensure_arduino_installation.rb` to enable testing with custom 3rd-party libraries
* Mock `attachInterrupt` and `detatchInterrupt`
* Return to the state where the OSX splash screen is hidden

## Issues Fixed

* Fixes #57 
* Fixes #13 (hopefully)
* Supercedes #53 
