### PR TITLE
Additional CI fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Arduino command wrapper now natively supports board manager URLs
 
 ### Changed
 - Centralized file listing code in `arduino_ci_remote.rb`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Arduino command wrapper now natively supports board manager URLs
 - CI checks for proper board manager URLs for requested platforms
+- CI reports on Arduino executable location
 
 ### Changed
 - Centralized file listing code in `arduino_ci_remote.rb`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Arduino command wrapper now natively supports board manager URLs
 - `arduino_ci_remote.rb` checks for proper board manager URLs for requested platforms
 - `arduino_ci_remote.rb` reports on Arduino executable location
+- exposed `index_libraries` in `ArduinoCmd` so it can be used as an explicit build step
 
 ### Changed
 - Centralized file listing code in `arduino_ci_remote.rb`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Centralized file listing code in `arduino_ci_remote.rb`
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Arduino command wrapper now natively supports board manager URLs
+- CI checks for proper board manager URLs for requested platforms
 
 ### Changed
 - Centralized file listing code in `arduino_ci_remote.rb`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Deprecated
 
 ### Removed
+- Linux wrapper no longer bails out on long-running commands.  That behavior was possible in Arduino 1.6.x that might pop up a graphical error message, but with the display manager removed this is no longer a concern
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Arduino command wrapper now natively supports board manager URLs
-- CI checks for proper board manager URLs for requested platforms
-- CI reports on Arduino executable location
+- `arduino_ci_remote.rb` checks for proper board manager URLs for requested platforms
+- `arduino_ci_remote.rb` reports on Arduino executable location
 
 ### Changed
 - Centralized file listing code in `arduino_ci_remote.rb`
+- `arduino_ci_remote.rb` is verbose about platforms, packages, and URLs
 
 ### Deprecated
 

--- a/exe/arduino_ci_remote.rb
+++ b/exe/arduino_ci_remote.rb
@@ -161,7 +161,7 @@ all_packages = all_platforms.values.map { |v| v[:package] }.uniq.reject(&:nil?)
 all_urls = all_packages.map { |p| config.package_url(p) }.uniq.reject(&:nil?)
 unless all_urls.empty?
   assure("Setting board manager URLs") do
-    @arduino_cmd.set_pref("boardsmanager.additional.urls", all_urls.join(","))
+    @arduino_cmd.board_manager_urls = all_urls
   end
 end
 

--- a/exe/arduino_ci_remote.rb
+++ b/exe/arduino_ci_remote.rb
@@ -24,6 +24,10 @@ def terminate(final = nil)
 end
 
 # make a nice status line for an action and react to the action
+# TODO / note to self: inform_multline is tougher to write
+#   without altering the signature because it only leaves space
+#   for the checkmark _after_ the multiline, it doesn't know how
+#   to make that conditionally the body
 def perform_action(message, multiline, mark_fn, on_fail_msg, tally_on_fail, abort_on_fail)
   line = "#{message}... "
   endline = "...#{message} "

--- a/exe/arduino_ci_remote.rb
+++ b/exe/arduino_ci_remote.rb
@@ -109,6 +109,9 @@ config = ArduinoCI::CIConfig.default.from_project_library
 @arduino_cmd = ArduinoCI::ArduinoInstallation.autolocate!
 inform("Located Arduino binary") { @arduino_cmd.binary_path.to_s }
 
+# index the existing libraries
+attempt("Indexing libraries") { @arduino_cmd.index_libraries } unless @arduino_cmd.libraries_indexed
+
 # initialize library under test
 installed_library_path = attempt("Installing library under test") do
   @arduino_cmd.install_local_library(Pathname.new("."))

--- a/exe/arduino_ci_remote.rb
+++ b/exe/arduino_ci_remote.rb
@@ -103,6 +103,7 @@ end
 # initialize command and config
 config = ArduinoCI::CIConfig.default.from_project_library
 @arduino_cmd = ArduinoCI::ArduinoInstallation.autolocate!
+inform("Located Arduino binary") { @arduino_cmd.binary_path.to_s }
 
 # initialize library under test
 installed_library_path = attempt("Installing library under test") do

--- a/exe/arduino_ci_remote.rb
+++ b/exe/arduino_ci_remote.rb
@@ -112,6 +112,7 @@ if installed_library_path.exist?
   inform("Library installed at") { installed_library_path.to_s }
 else
   assure_multiline("Library installed successfully") do
+    # print out the contents of the deepest directory we actually find
     @arduino_cmd.lib_dir.ascend do |path_part|
       next unless path_part.exist?
 

--- a/exe/arduino_ci_remote.rb
+++ b/exe/arduino_ci_remote.rb
@@ -144,9 +144,13 @@ all_platforms = {}
 aux_libraries = Set.new(config.aux_libraries_for_unittest + config.aux_libraries_for_build)
 # while collecting the platforms, ensure they're defined
 config.platforms_to_unittest.each { |p| all_platforms[p] = assured_platform("unittest", p, config) }
+example_platforms = {}
 library_examples.each do |path|
   ovr_config = config.from_example(path)
-  ovr_config.platforms_to_build.each { |p| all_platforms[p] = assured_platform("library example", p, config) }
+  ovr_config.platforms_to_build.each do |p|
+    # assure the platform if we haven't already
+    example_platforms[p] = all_platforms[p] = assured_platform("library example", p, config) unless example_platforms.key?(p)
+  end
   aux_libraries.merge(ovr_config.aux_libraries_for_build)
 end
 

--- a/lib/arduino_ci/arduino_cmd.rb
+++ b/lib/arduino_ci/arduino_cmd.rb
@@ -18,9 +18,13 @@ module ArduinoCI
       self.class_eval("def flag_#{name};\"#{text}\";end", __FILE__, __LINE__)
     end
 
-    # the path to the Arduino executable
-    # @return [String]
+    # the array of command components to launch the Arduino executable
+    # @return [Array<String>]
     attr_accessor :base_cmd
+
+    # the actual path to the executable on this platform
+    # @return [Pathname]
+    attr_accessor :binary_path
 
     # part of a workaround for https://github.com/arduino/Arduino/issues/3535
     attr_reader   :library_is_indexed

--- a/lib/arduino_ci/arduino_cmd.rb
+++ b/lib/arduino_ci/arduino_cmd.rb
@@ -145,13 +145,6 @@ module ArduinoCI
       ret
     end
 
-    # run a command and don't capture its output, but use the same signature
-    # @return [Hash] {:out => String, :err => String, :success => bool}
-    def run_wrap(*args, **kwargs)
-      success = run(*args, **kwargs)
-      { out: "NOPE, use run_and_capture", err: "NOPE, use run_and_capture", success: success }
-    end
-
     # check whether a board is installed
     # we do this by just selecting a board.
     #   the arduino binary will error if unrecognized and do a successful no-op if it's installed

--- a/lib/arduino_ci/arduino_cmd.rb
+++ b/lib/arduino_ci/arduino_cmd.rb
@@ -145,6 +145,21 @@ module ArduinoCI
       ret
     end
 
+    # Board manager URLs
+    # @return [Array<String>] The additional URLs used by the board manager
+    def board_manager_urls
+      url_list = get_pref("boardsmanager.additional.urls")
+      return [] if url_list.nil?
+
+      url_list.split(",")
+    end
+
+    # Set board manager URLs
+    # @return [Array<String>] The additional URLs used by the board manager
+    def board_manager_urls=(all_urls)
+      set_pref("boardsmanager.additional.urls", all_urls.join(","))
+    end
+
     # check whether a board is installed
     # we do this by just selecting a board.
     #   the arduino binary will error if unrecognized and do a successful no-op if it's installed

--- a/lib/arduino_ci/arduino_cmd_linux.rb
+++ b/lib/arduino_ci/arduino_cmd_linux.rb
@@ -5,9 +5,6 @@ module ArduinoCI
 
   # Implementation of Arduino linux IDE commands
   class ArduinoCmdLinux < ArduinoCmd
-
-    attr_reader :prefs_response_time
-
     flag :get_pref,        "--get-pref"
     flag :set_pref,        "--pref"
     flag :save_prefs,      "--save-prefs"
@@ -15,61 +12,6 @@ module ArduinoCI
     flag :install_boards,  "--install-boards"
     flag :install_library, "--install-library"
     flag :verify,          "--verify"
-
-    def initialize
-      super
-      @prefs_response_time = nil
-    end
-
-    # fetch preferences in their raw form
-    # @return [String] Preferences as a set of lines
-    def _prefs_raw
-      start = Time.now
-      resp = run_and_capture(flag_get_pref)
-      @prefs_response_time = Time.now - start
-      return nil unless resp[:success]
-
-      resp[:out]
-    end
-
-    def run_with_gui_guess(message, *args, **kwargs)
-      # On Travis CI, we get an error message in the GUI instead of on STDERR
-      # so, assume that if we don't get a rapid reply that things are not installed
-
-      prefs if @prefs_response_time.nil?
-      x3 = @prefs_response_time * 3
-      Timeout.timeout(x3) do
-        result = run_and_capture(*args, **kwargs)
-        result[:success]
-      end
-    rescue Timeout::Error
-      puts "No response in #{x3} seconds. Assuming graphical modal error message#{message}."
-      false
-    end
-
-    # underlying preference-setter.
-    # @param key [String] the preference key
-    # @param value [String] the preference value
-    # @return [bool] whether the command succeeded
-    def _set_pref(key, value)
-      run_with_gui_guess(" about preferences", flag_set_pref, "#{key}=#{value}", flag_save_prefs)
-    end
-
-    # check whether a board is installed
-    # we do this by just selecting a board.
-    #   the arduino binary will error if unrecognized and do a successful no-op if it's installed
-    # @param boardname [String] The name of the board
-    # @return [bool]
-    def board_installed?(boardname)
-      run_with_gui_guess(" about board not installed", flag_use_board, boardname)
-    end
-
-    # use a particular board for compilation
-    # @param boardname [String] The name of the board
-    def use_board(boardname)
-      run_with_gui_guess(" about board not installed", flag_use_board, boardname, flag_save_prefs)
-    end
-
   end
 
 end

--- a/lib/arduino_ci/arduino_installation.rb
+++ b/lib/arduino_ci/arduino_installation.rb
@@ -78,11 +78,11 @@ module ArduinoCI
           # don't want to see is a java error.
           args = launcher + ["--bogus-option"]
           result = Host.run_and_capture(*args)
-          if result[:err].include? "Error: unknown option: --bogus-option"
-            ret.base_cmd = launcher
-            ret.binary_path = Pathname.new(osx_root)
-            return ret
-          end
+          next unless result[:err].include? "Error: unknown option: --bogus-option"
+
+          ret.base_cmd = launcher
+          ret.binary_path = Pathname.new(osx_root)
+          return ret
         end
         nil
       end

--- a/lib/arduino_ci/arduino_installation.rb
+++ b/lib/arduino_ci/arduino_installation.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 require "arduino_ci/host"
 require "arduino_ci/arduino_cmd_osx"
 require "arduino_ci/arduino_cmd_linux"
@@ -32,12 +33,14 @@ module ArduinoCI
 
           ret = ArduinoCmdLinux.new
           ret.base_cmd = [loc]
+          ret.binary_path = Pathname.new(loc)
         when :windows then
           loc = ArduinoDownloaderWindows.autolocated_executable
           return nil if loc.nil?
 
           ret = ArduinoCmdWindows.new
           ret.base_cmd = [loc]
+          ret.binary_path = Pathname.new(loc)
         end
         ret
       end
@@ -77,6 +80,7 @@ module ArduinoCI
           result = Host.run_and_capture(*args)
           if result[:err].include? "Error: unknown option: --bogus-option"
             ret.base_cmd = launcher
+            ret.binary_path = Pathname.new(osx_root)
             return ret
           end
         end

--- a/lib/arduino_ci/ci_config.rb
+++ b/lib/arduino_ci/ci_config.rb
@@ -191,6 +191,13 @@ module ArduinoCI
       deep_clone(defn)
     end
 
+    # Whether a package is built-in to arduino
+    # @param package [String] the package name (e.g. "arduino:avr")
+    # @return [bool]
+    def package_builtin?(package)
+      package.start_with?("arduino:")
+    end
+
     # the URL that gives the download info for a given package (a JSON file).
     # this is NOT where the package comes from.
     # @param package [String] the package name (e.g. "arduino:avr")

--- a/lib/arduino_ci/cpp_library.rb
+++ b/lib/arduino_ci/cpp_library.rb
@@ -57,11 +57,7 @@ module ArduinoCI
       return false unless base.exist?
 
       real = base.realpath
-      path.ascend do |path_part|
-        return true if path_part == base
-        return true if path_part == real
-      end
-      false
+      path.ascend.any? { |part| part == base || part == real }
     end
 
     # Check whether libasan (and by extension -fsanitizer=address) is supported
@@ -98,15 +94,10 @@ module ArduinoCI
     # CPP files that are part of the project library under test
     # @return [Array<Pathname>]
     def cpp_files
-      real_tests_dir = tests_dir.realpath
+      tests_dir_aliases = [tests_dir, tests_dir.realpath]
       cpp_files_in(@base_dir).reject do |p|
-        next true if p.ascend do |path_part|
-          break true if path_part == tests_dir
-          break true if path_part == real_tests_dir
-          break true if vendor_bundle?(p)
-        end
-
-        false
+        # ignore anything in the vendor bundle or tests dir
+        vendor_bundle?(p) || (p.ascend.any? { |part| tests_dir_aliases.include?(part) })
       end
     end
 

--- a/misc/default.yml
+++ b/misc/default.yml
@@ -7,8 +7,13 @@ packages:
     url: http://arduino.esp8266.com/stable/package_esp8266com_index.json
   adafruit:avr:
     url: https://adafruit.github.io/arduino-board-index/package_adafruit_index.json
+  adafruit:samd:
+    url: https://adafruit.github.io/arduino-board-index/package_adafruit_index.json
+  esp32:esp32:
+    url: https://dl.espressif.com/dl/package_esp32_index.json
 
 platforms:
+
   uno:
     board: arduino:avr:uno
     package: ~
@@ -35,6 +40,14 @@ platforms:
       defines:
        - __SAMD21G18A__
        - ARDUINO_SAMD_ZERO
+      warnings:
+      flags:
+  esp32:
+    board: esp32:esp32:featheresp32:FlashFreq=80
+    package: esp32:esp32
+    gcc:
+      features:
+      defines:
       warnings:
       flags:
   esp8266:
@@ -70,6 +83,39 @@ platforms:
       defines:
       warnings:
       flags:
+  m4:
+    board: adafruit:samd:adafruit_metro_m4
+    package: adafruit:samd
+    gcc:
+      features:
+      defines:
+      warnings:
+      flags:
+  mega2560:
+    board: arduino:avr:mega:cpu=atmega2560
+    package: arduino:avr
+    gcc:
+      features:
+      defines:
+      warnings:
+      flags:
+  cplayClassic:
+    board: arduino:avr:circuitplay32u4cat
+    package: arduino:avr
+    gcc:
+      features:
+      defines:
+      warnings:
+      flags:
+  cplayExpress:
+    board: arduino:samd:adafruit_circuitplayground_m0
+    package: arduino:samd
+    gcc:
+      features:
+      defines:
+      warnings:
+      flags:
+
 
 compile:
   libraries: ~
@@ -78,6 +124,10 @@ compile:
     - due
     - zero
     - leonardo
+    - m4
+    - esp32
+    - esp8266
+    - mega2560
 
 unittest:
   compilers:

--- a/misc/default.yml
+++ b/misc/default.yml
@@ -3,6 +3,7 @@
 #   https://en.wikipedia.org/wiki/List_of_Arduino_boards_and_compatible_systems
 
 packages:
+  # arduino:xxx are builtin, we don't need to include them here
   esp8266:esp8266:
     url: http://arduino.esp8266.com/stable/package_esp8266com_index.json
   adafruit:avr:
@@ -16,7 +17,7 @@ platforms:
 
   uno:
     board: arduino:avr:uno
-    package: ~
+    package: arduino:avr
     gcc:
       features:
       defines:
@@ -60,7 +61,7 @@ platforms:
       flags:
   leonardo:
     board: arduino:avr:leonardo
-    package: ~
+    package: arduino:avr
     gcc:
       features:
       defines:

--- a/spec/arduino_cmd_spec.rb
+++ b/spec/arduino_cmd_spec.rb
@@ -65,6 +65,23 @@ RSpec.describe ArduinoCI::ArduinoCmd do
     end
   end
 
+
+  context "board_manager" do
+    it "Reads and writes board_manager URLs" do
+      fake_urls = ["http://foo.bar", "http://arduino.ci"]
+      existing_urls = arduino_cmd.board_manager_urls
+
+      # try to ensure maxiumum variability in the test
+      test_url_sets = (existing_urls.empty? ? [fake_urls, []] : [[], fake_urls]) + [existing_urls]
+
+      test_url_sets.each do |urls|
+        arduino_cmd.board_manager_urls = urls
+        expect(arduino_cmd.board_manager_urls).to match_array(urls)
+      end
+    end
+  end
+
+
   context "verify_sketch" do
 
     sketch_path_ino = get_sketch("FakeSketch", "FakeSketch.ino")

--- a/spec/ci_config_spec.rb
+++ b/spec/ci_config_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ArduinoCI::CIConfig do
       expect(zero[:gcc].class).to eq(Hash)
 
       expect(default_config.package_url("adafruit:avr")).to eq("https://adafruit.github.io/arduino-board-index/package_adafruit_index.json")
-      expect(default_config.platforms_to_build).to match(["uno", "due", "zero", "leonardo"])
+      expect(default_config.platforms_to_build).to match(["uno", "due", "zero", "leonardo", "m4", "esp32", "esp8266", "mega2560"])
       expect(default_config.platforms_to_unittest).to match(["uno", "due", "zero", "leonardo"])
       expect(default_config.aux_libraries_for_build).to match([])
       expect(default_config.aux_libraries_for_unittest).to match([])

--- a/spec/ci_config_spec.rb
+++ b/spec/ci_config_spec.rb
@@ -24,7 +24,12 @@ RSpec.describe ArduinoCI::CIConfig do
       expect(zero[:package]).to eq("arduino:samd")
       expect(zero[:gcc].class).to eq(Hash)
 
+      expect(default_config.package_builtin?("arduino:avr")).to be true
+      expect(default_config.package_builtin?("adafruit:avr")).to be false
+
       expect(default_config.package_url("adafruit:avr")).to eq("https://adafruit.github.io/arduino-board-index/package_adafruit_index.json")
+      expect(default_config.package_url("adafruit:samd")).to eq("https://adafruit.github.io/arduino-board-index/package_adafruit_index.json")
+      expect(default_config.package_url("esp32:esp32")).to eq("https://dl.espressif.com/dl/package_esp32_index.json")
       expect(default_config.platforms_to_build).to match(["uno", "due", "zero", "leonardo", "m4", "esp32", "esp8266", "mega2560"])
       expect(default_config.platforms_to_unittest).to match(["uno", "due", "zero", "leonardo"])
       expect(default_config.aux_libraries_for_build).to match([])


### PR DESCRIPTION
## Highlights from `CHANGELOG.md`

* Improved file listings for unit test dir on failure to find tests
* Reduced redundant log lines in CI script
* Removed graphical workarounds in Linux since they no longer seem necessary
* Expose setter/getter for board manager URLs in `ArduinoCmd`
* Expose library indexing in `ArduinoCmd`
* Report path of Arduino binary
* Explicitly check on various aspects of config YML to make sure everything referenced is defined


