### PR TITLE
Avoid duplicate file entries in list of files to compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Under some circumstances, some files were given multiple times as arguments to the compiler, causing compilation failure. This has been fixed.
+
 ### Security
 
 

--- a/lib/arduino_ci/cpp_library.rb
+++ b/lib/arduino_ci/cpp_library.rb
@@ -248,7 +248,8 @@ module ArduinoCI
         cgc = ci_gcc_config
         ret = feature_args(cgc) + warning_args(cgc) + define_args(cgc) + flag_args(cgc) + ret
       end
-      ret
+      ret.uniq   # Using uniq to remove duplicate entries of files that might be picked up multiple
+                 # times above (e.g Arduino.cpp, Godmode.cpp, ArduinoUnitTests.cpp, etc).
     end
 
     # build a file for running a test of the given unit test file


### PR DESCRIPTION
## Highlights from `CHANGELOG.md`

* See CHANGELOG.md for more

## Issues Fixed

* Fixes #69
