### PR TITLE
Provide missing itoa function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 
+- Provide an `itoa` function. It is present in Arduino's runtime environment but not on most (all?) host systems because itoa is not a portable standard function.
+
 ### Changed
 
 ### Deprecated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,23 @@ Pull requests will trigger a Travis CI job.  The following two commands will be 
  * `rubocop -D` - code style tests
  * `rspec` - functional tests
 
+ If you do not already have a working ruby development environment set up, run the following commands:
+
+```shell
+apt-get install ruby ruby-dev    # For Debian/Ubuntu
+dnf install ruby ruby-devel      # For Fedora
+yum install ruby ruby-devel      # For Centos/RHEL
+gem install bundler              # See note below about version
+gem install rubocop
+gem install rspec
+```
+
+As of writing this you want install a version 1 of bundler, `gem install bundler -v '1.17.3'`,
+since there is some incompability with regards to the
+[latest version 2 release of bundler](https://bundler.io/blog/2019/01/04/an-update-on-the-bundler-2-release.html)
+
 Be prepared to write tests to accompany any code you would like to see merged.
+See `SampleProjects/TestSomething/test/*.cpp` for the existing tests (run by rspec).
 
 
 ## Packaging the Gem

--- a/SampleProjects/TestSomething/test/stdlib.cpp
+++ b/SampleProjects/TestSomething/test/stdlib.cpp
@@ -1,0 +1,46 @@
+#include <ArduinoUnitTests.h>
+#include <Arduino.h>
+
+#define ARRAY_SIZEOF(a) ( sizeof(a) / sizeof((a)[0]) )
+
+unittest(library_tests_itoa)
+{
+  char buf[32];
+  const char *result;
+  struct {
+    int value;
+    const char *expected;
+    int base;
+  } table[] = {
+    { 54325, "1101010000110101", 2 },
+    { 54325, "54325", 10 },
+    { 54325, "D435", 16 },
+    { 493, "755", 8 },
+    { -1, "-1", 10 },
+    { 32767, "32767", 10},
+    { 32767, "7FFF", 16},
+    { 65535, "65535", 10},
+    { 65535, "FFFF", 16},
+    { 2147483647, "2147483647", 10},
+    { 2147483647, "7FFFFFFF", 16},
+  };
+
+  for (int i = 0; i < ARRAY_SIZEOF(table); i++) {
+    result = itoa(table[i].value, buf, table[i].base);
+    assertEqual(table[i].expected, result);
+  }
+
+  // While only bases 2, 8, 10 and 16 are of real interest, lets test that all
+  // bases at least produce expected output for a few test points simple to test.
+  for (int base = 2; base <= 16; base++) {
+    result = itoa(0, buf, base);
+    assertEqual("0", result);
+    result = itoa(1, buf, base);
+    assertEqual("1", result);
+    result = itoa(base, buf, base);
+    assertEqual("10", result);
+  }
+
+}
+
+unittest_main()

--- a/cpp/arduino/stdlib.cpp
+++ b/cpp/arduino/stdlib.cpp
@@ -1,9 +1,9 @@
 
-#if 0 // This code is copied from https://people.cs.umu.se/isak/snippets/ltoa.c
+#if 1 // This code is copied from https://people.cs.umu.se/isak/snippets/ltoa.c and then converted from ltoa to itoa.
 /*
 **  LTOA.C
 **
-**  Converts a long integer to a string.
+**  Converts a integer to a string.
 **
 **  Copyright 1988-90 by Robert B. Stout dba MicroFirm
 **
@@ -21,12 +21,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define BUFSIZE (sizeof(long) * 8 + 1)
+#define BUFSIZE (sizeof(int) * 8 + 1)
 
-char *ltoa(long N, char *str, int base)
+char *itoa(int N, char *str, int base)
 {
-      register int i = 2;
-      long uarg;
+      int i = 2;
+      int uarg;
       char *tail, *head = str, buf[BUFSIZE];
 
       if (36 < base || 2 > base)
@@ -45,7 +45,7 @@ char *ltoa(long N, char *str, int base)
       {
             for (i = 1; uarg; ++i)
             {
-                  register ldiv_t r;
+                  ldiv_t r;
 
                   r       = ldiv(uarg, base);
                   *tail-- = (char)(r.rem + ((9L < r.rem) ?

--- a/cpp/arduino/stdlib.cpp
+++ b/cpp/arduino/stdlib.cpp
@@ -1,0 +1,61 @@
+
+#if 0 // This code is copied from https://people.cs.umu.se/isak/snippets/ltoa.c
+/*
+**  LTOA.C
+**
+**  Converts a long integer to a string.
+**
+**  Copyright 1988-90 by Robert B. Stout dba MicroFirm
+**
+**  Released to public domain, 1991
+**
+**  Parameters: 1 - number to be converted
+**              2 - buffer in which to build the converted string
+**              3 - number base to use for conversion
+**
+**  Returns:  A character pointer to the converted string if
+**            successful, a NULL pointer if the number base specified
+**            is out of range.
+*/
+
+#include <stdlib.h>
+#include <string.h>
+
+#define BUFSIZE (sizeof(long) * 8 + 1)
+
+char *ltoa(long N, char *str, int base)
+{
+      register int i = 2;
+      long uarg;
+      char *tail, *head = str, buf[BUFSIZE];
+
+      if (36 < base || 2 > base)
+            base = 10;                    /* can only use 0-9, A-Z        */
+      tail = &buf[BUFSIZE - 1];           /* last character position      */
+      *tail-- = '\0';
+
+      if (10 == base && N < 0L)
+      {
+            *head++ = '-';
+            uarg    = -N;
+      }
+      else  uarg = N;
+
+      if (uarg)
+      {
+            for (i = 1; uarg; ++i)
+            {
+                  register ldiv_t r;
+
+                  r       = ldiv(uarg, base);
+                  *tail-- = (char)(r.rem + ((9L < r.rem) ?
+                                  ('A' - 10L) : '0'));
+                  uarg    = r.quot;
+            }
+      }
+      else  *tail-- = '0';
+
+      memcpy(head, ++tail, i);
+      return str;
+}
+#endif

--- a/cpp/arduino/stdlib.h
+++ b/cpp/arduino/stdlib.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// Header file to compensate for differences between
+// arduino-1.x.x/hardware/tools/avr/avr/include/stdlib.h and /usr/include/stdlib.h.
+
+#include_next <stdlib.h>
+
+/*
+ * Arduino stdlib.h includes a prototype for itoa which is not a standard function,
+ * and is not available in /usr/include/stdlib.h. Provide one here.
+ * http://www.cplusplus.com/reference/cstdlib/itoa/
+ * https://stackoverflow.com/questions/190229/where-is-the-itoa-function-in-linux
+ */
+char *itoa(int val, char *s, int radix);


### PR DESCRIPTION
Provide an `itoa` function. It is present in Arduino's runtime environment but not on most (all?) host systems because itoa is not a portable standard function.