### PR TITLE
Bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+- Spaces in the names of project directores no longer cause unit test binaries to fail execution
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Checking for (empty) set of platforms to build now precedes the check for examples to build; this avoids assuming that all libraries will have an example and dumping the file set when none are found
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Spaces in the names of project directores no longer cause unit test binaries to fail execution
+- Configuration file overrides with `nil`s (or empty arrays) now properly override their base configuration
 
 ### Security
 

--- a/exe/arduino_ci_remote.rb
+++ b/exe/arduino_ci_remote.rb
@@ -263,8 +263,11 @@ else
   end
 end
 
-if library_examples.empty?
-  inform_multiline("Skipping libraries; no examples found in #{installed_library_path}") do
+puts "config.platforms_to_build : #{config.platforms_to_build}"
+if config.platforms_to_build.empty?
+  inform("Skipping builds") { "no platforms were requested" }
+elsif library_examples.empty?
+  inform_multiline("Skipping builds; no examples found in #{installed_library_path}") do
     display_files(installed_library_path)
   end
 else

--- a/lib/arduino_ci/ci_config.rb
+++ b/lib/arduino_ci/ci_config.rb
@@ -93,7 +93,7 @@ module ArduinoCI
         if !schema.include?(ksym)
           puts "Warning: unknown field '#{ksym}' under definition for #{rootname}"
         elsif value.nil?
-          # unspecificed, that's fine
+          good_data[ksym] = nil
         elsif value.class != expected_type
           puts "Warning: expected field '#{ksym}' of #{rootname} to be '#{expected_type}', got '#{value.class}'"
         else

--- a/lib/arduino_ci/cpp_library.rb
+++ b/lib/arduino_ci/cpp_library.rb
@@ -1,6 +1,7 @@
 require 'find'
 require "arduino_ci/host"
 require 'pathname'
+require 'shellwords'
 
 HPP_EXTENSIONS = [".hpp", ".hh", ".h", ".hxx", ".h++"].freeze
 CPP_EXTENSIONS = [".cpp", ".cc", ".c", ".cxx", ".c++"].freeze
@@ -287,7 +288,7 @@ module ArduinoCI
       @last_cmd = executable
       @last_out = ""
       @last_err = ""
-      Host.run_and_output(executable.to_s)
+      Host.run_and_output(executable.to_s.shellescape)
     end
 
   end


### PR DESCRIPTION
## Highlights from `CHANGELOG.md`

* Check that example builds are actually desired before complaining that none were found
* Fix behavior of config file, where falsey values (empty arrays specifically) did not properly override existing values
* Project directory names can now contain spaces instead of failing cryptically 
* See CHANGELOG.md for more

