### PR TITLE
Small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-
 - Provide an `itoa` function. It is present in Arduino's runtime environment but not on most (all?) host systems because itoa is not a portable standard function.
 
 ### Changed
+- Simplified the use of `Array.each` with a return statement; it's now simply `Array.find`
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Simplified the use of `Array.each` with a return statement; it's now simply `Array.find`
+- `autolocate!` for Arduino installations now raises `ArduinoInstallationError` if `force_install` fails
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Simplified the use of `Array.each` with a return statement; it's now simply `Array.find`
 - `autolocate!` for Arduino installations now raises `ArduinoInstallationError` if `force_install` fails
+- Errors due to missing YAML are now named `ConfigurationError`
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+- Determining a working OSX launch command no longer breaks on non-English installations
 
 ### Security
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -405,7 +405,8 @@ unittest(interrupt_attachment) {
   assertEqual(state->interrupt[7].mode, 3);
   detachInterrupt(7);
   assertFalse(state->interrupt[7].attached);
-}```
+}
+```
 
 
 ### SPI

--- a/lib/arduino_ci/arduino_downloader.rb
+++ b/lib/arduino_ci/arduino_downloader.rb
@@ -186,7 +186,7 @@ module ArduinoCI
       elsif File.exist? extracted_file
         install
       else
-        puts "Arduino force-install failed"
+        puts "Could not find extracted archive (tried #{extracted_file})"
       end
 
       File.exist? self.class.force_install_location

--- a/lib/arduino_ci/arduino_downloader.rb
+++ b/lib/arduino_ci/arduino_downloader.rb
@@ -32,13 +32,7 @@ module ArduinoCI
       # if it exists.  I'm not sure why we would have both, but if we did
       # a force install then let's make sure we actually use it.
       locations = [self.force_installed_executable, self.existing_executable]
-      locations.each do |loc|
-        next if loc.nil?
-        next unless File.exist? loc
-
-        return loc
-      end
-      nil
+      locations.find { |loc| !loc.nil? && File.exist?(loc) }
     end
 
     # The autolocated directory of the installation
@@ -49,13 +43,7 @@ module ArduinoCI
       # if it exists.  I'm not sure why we would have both, but if we did
       # a force install then let's make sure we actually use it.
       locations = [self.force_install_location, self.existing_installation]
-      locations.each do |loc|
-        next if loc.nil?
-        next unless File.exist? loc
-
-        return loc
-      end
-      nil
+      locations.find { |loc| !loc.nil? && File.exist?(loc) }
     end
 
     # The path to the directory of an existing installation, or nil

--- a/lib/arduino_ci/arduino_downloader_osx.rb
+++ b/lib/arduino_ci/arduino_downloader_osx.rb
@@ -27,21 +27,17 @@ module ArduinoCI
     # @param Array<string> a list of places to look
     # @return [string]
     def self.find_existing_arduino_dir(paths)
-      paths.each do |path|
-        return path if File.exist? path
-      end
-      nil
+      paths.find(&File.method(:exist?))
     end
 
     # An existing Arduino file in one of the given directories, or nil
     # @param Array<string> a list of places to look for the executable
     # @return [string]
     def self.find_existing_arduino_exe(paths)
-      paths.each do |path|
+      paths.find do |path|
         exe = File.join(path, "MacOS", "Arduino")
-        return exe if File.exist? exe
+        File.exist? exe
       end
-      nil
     end
 
     # The path to the directory of an existing installation, or nil

--- a/lib/arduino_ci/arduino_downloader_windows.rb
+++ b/lib/arduino_ci/arduino_downloader_windows.rb
@@ -81,10 +81,10 @@ module ArduinoCI
     # @return [string]
     def self.existing_executable
       arduino_reg = 'SOFTWARE\WOW6432Node\Arduino'
-      Win32::Registry::HKEY_LOCAL_MACHINE.open(arduino_reg) do |reg|
+      Win32::Registry::HKEY_LOCAL_MACHINE.open(arduino_reg).find do |reg|
         path = reg.read_s('Install_Dir')
         exe = File.join(path, "arduino_debug.exe")
-        return exe if File.exist? exe
+        File.exist? exe
       end
     rescue
       nil
@@ -93,10 +93,7 @@ module ArduinoCI
     # The executable Arduino file in a forced installation, or nil
     # @return [string]
     def self.force_installed_executable
-      exe = File.join(self.force_install_location, "arduino_debug.exe")
-      return nil if exe.nil?
-
-      exe
+      File.join(self.force_install_location, "arduino_debug.exe")
     end
 
   end

--- a/lib/arduino_ci/arduino_installation.rb
+++ b/lib/arduino_ci/arduino_installation.rb
@@ -13,6 +13,8 @@ DESIRED_ARDUINO_IDE_VERSION = "1.8.6".freeze
 
 module ArduinoCI
 
+  class ArduinoInstallationError < StandardError; end
+
   # Manage the OS-specific install location of Arduino
   class ArduinoInstallation
 
@@ -94,7 +96,8 @@ module ArduinoCI
         return candidate unless candidate.nil?
 
         # force the install
-        force_install
+        raise ArduinoInstallationError, "Failed to force-install Arduino" unless force_install
+
         autolocate
       end
 

--- a/lib/arduino_ci/arduino_installation.rb
+++ b/lib/arduino_ci/arduino_installation.rb
@@ -80,7 +80,13 @@ module ArduinoCI
           # don't want to see is a java error.
           args = launcher + ["--bogus-option"]
           result = Host.run_and_capture(*args)
-          next unless result[:err].include? "Error: unknown option: --bogus-option"
+
+          # NOTE: Was originally searching for "Error: unknown option: --bogus-option"
+          #           but also need to find "Erreur: option inconnue : --bogus-option"
+          #           and who knows how many other languages.
+          # For now, just search for the end of the error and hope that the java-style
+          #  launch of this won't include a similar string in it
+          next unless result[:err].include? ": --bogus-option"
 
           ret.base_cmd = launcher
           ret.binary_path = Pathname.new(osx_root)

--- a/lib/arduino_ci/ci_config.rb
+++ b/lib/arduino_ci/ci_config.rb
@@ -35,6 +35,8 @@ UNITTEST_SCHEMA = {
 }.freeze
 module ArduinoCI
 
+  class ConfigurationError < StandardError; end
+
   # The filename controlling (overriding) the defaults for testing.
   # Files with this name can be used in the root directory of the Arduino library and in any/all of the example directories
   CONFIG_FILENAMES = [
@@ -108,7 +110,7 @@ module ArduinoCI
     # @return [ArduinoCI::CIConfig] a reference to self
     def load_yaml(path)
       yml = YAML.load_file(path)
-      raise "The YAML file at #{path} failed to load" unless yml
+      raise ConfigurationError, "The YAML file at #{path} failed to load" unless yml
 
       if yml.include?("packages")
         yml["packages"].each do |k, v|


### PR DESCRIPTION
## Highlights from `CHANGELOG.md`
- Simplified the use of `Array.each` with a return statement; it's now simply `Array.find`
- `autolocate!` for Arduino installations now raises `ArduinoInstallationError` if `force_install` fails
- Errors due to missing YAML are now named `ConfigurationError`
- typo in documentation fixed
* See CHANGELOG.md for more

* Fixes #78 
