### PR TITLE
Enable redirection of installation output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- `ArduinoInstallation` and `ArduinoDownloader` now allow console output to optionally be set to an `IO` object of choice during `force_install`
+- `ArduinoInstallation::force_install` now optionally accepts a version string
 
 ### Changed
 - Unit tests and examples are now executed alphabetically by filename

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - `ArduinoInstallation` and `ArduinoDownloader` now allow console output to optionally be set to an `IO` object of choice during `force_install`
 - `ArduinoInstallation::force_install` now optionally accepts a version string
+- `arduino_library_location.rb` script to print Arduino library location to stdout
 
 ### Changed
 - Unit tests and examples are now executed alphabetically by filename

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -138,7 +138,7 @@ However, more flexible usage is available:
 
 Sometimes you need a fork of an Arduino library instead of the version that will be installed via their GUI.  `arduino_ci_remote.rb` won't overwrite existing downloaded libraries with fresh downloads, but it won't fetch the custom versions for you either.
 
-If this is the behavior you need, `ensure_arduino_installation.rb` is for you.
+If this is the behavior you need, `ensure_arduino_installation.rb` is for you.  It ensures that an Arduino binary is available on the system.
 
 ```shell
 # Example build script
@@ -147,14 +147,20 @@ bundle install
 # ensure the Arduino installation -- creates the Library directory
 bundle exec ensure_arduino_installation.rb
 
-# manually install the custom version you need
+# manually install a custom library from a zip file
+wget https://hosting.com/custom_library.zip
+unzip -o custom_library.zip
+mv custom_library $(bundle exec arduino_library_location.rb)
+
+# manually install a custom library from a git repository
 git clone https://repository.com/custom_library_repo.git
-mv custom_library_repo /path/to/Arduino/libraries
+mv custom_library_repo $(bundle exec arduino_library_location.rb)
 
 # now run CI
 bundle exec arduino_ci_remote.rb
 ```
 
+Note the use of subshell to execute `bundle exec arduino_library_location.rb`.  This command simply returns the directory in which Arduino Libraries are (or should be) installed.
 
 
 

--- a/exe/arduino_library_location.rb
+++ b/exe/arduino_library_location.rb
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+require 'arduino_ci'
+
+# locate and/or forcibly install Arduino, keep stdout clean
+@arduino_cmd = ArduinoCI::ArduinoInstallation.autolocate!($stderr)
+
+puts @arduino_cmd.lib_dir

--- a/lib/arduino_ci/arduino_downloader_windows.rb
+++ b/lib/arduino_ci/arduino_downloader_windows.rb
@@ -2,6 +2,7 @@ require 'base64'
 require 'shellwords' # fingers crossed this works on win32
 require 'win32/registry'
 require "arduino_ci/arduino_downloader"
+require 'net/http'
 require "fileutils"
 
 module ArduinoCI
@@ -30,6 +31,8 @@ module ArduinoCI
       open(URI.parse(package_url), ssl_verify_mode: 0) do |url|
         File.open(package_file, 'wb') { |file| file.write(url.read) }
       end
+    rescue Net::OpenTimeout, Net::ReadTimeout, OpenURI::HTTPError, URI::InvalidURIError => e
+      @output.puts "\nArduino force-install failed downloading #{package_url}: #{e}"
     end
 
     # Move the extracted package file from extracted_file to the force_install_location

--- a/lib/arduino_ci/arduino_installation.rb
+++ b/lib/arduino_ci/arduino_installation.rb
@@ -97,25 +97,25 @@ module ArduinoCI
 
       # Attempt to find a workable Arduino executable across platforms, and install it if we don't
       # @return [ArduinoCI::ArduinoCmd] an instance of a command
-      def autolocate!
+      def autolocate!(output = $stdout)
         candidate = autolocate
         return candidate unless candidate.nil?
 
         # force the install
-        raise ArduinoInstallationError, "Failed to force-install Arduino" unless force_install
+        raise ArduinoInstallationError, "Failed to force-install Arduino" unless force_install(output)
 
         autolocate
       end
 
       # Forcibly install Arduino from the web
       # @return [bool] Whether the command succeeded
-      def force_install
+      def force_install(output = $stdout, version = DESIRED_ARDUINO_IDE_VERSION)
         worker_class =  case Host.os
                         when :osx then ArduinoDownloaderOSX
                         when :windows then ArduinoDownloaderWindows
                         when :linux then ArduinoDownloaderLinux
                         end
-        worker = worker_class.new(DESIRED_ARDUINO_IDE_VERSION)
+        worker = worker_class.new(version, output)
         worker.execute
       end
 

--- a/spec/arduino_installation_spec.rb
+++ b/spec/arduino_installation_spec.rb
@@ -15,5 +15,17 @@ RSpec.describe ArduinoCI::ArduinoInstallation do
     end
   end
 
+  context "force_install" do
+    it "Can redirect output" do
+      output = StringIO.new
+      output.rewind
+      expect(output.read.empty?).to be true
+      # install a bogus version to save time downloading
+      arduino_cmd = ArduinoCI::ArduinoInstallation.force_install(output, "BOGUS VERSION")
+      output.rewind
+      expect(output.read.empty?).to be false
+    end
+  end
+
 end
 


### PR DESCRIPTION
Adds ability to do cross-platform build scripts, ensuring that custom libraries get copied into the correct Arduino library directory.

## Highlights from `CHANGELOG.md`

- `ArduinoInstallation` and `ArduinoDownloader` now allow console output to optionally be set to an `IO` object of choice during `force_install`
- `ArduinoInstallation::force_install` now optionally accepts a version string
- `arduino_library_location.rb` script to print Arduino library location to stdout

## Issues Fixed

* Fixes #91