### PR TITLE
Handle nil from install_local_library in perform_compilation_tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Library installation no longer "fails" if the library is already installed
 - Platform definition for `mega2560` now includes proper AVR compiler flag
+- No longer crashes on problems installing library for compilation
 
 ### Security
 

--- a/exe/arduino_ci_remote.rb
+++ b/exe/arduino_ci_remote.rb
@@ -244,11 +244,7 @@ def perform_compilation_tests(config)
       false
     end
   end
-  if installed_library_path
-    library_examples = @arduino_cmd.library_examples(installed_library_path)
-  else
-    library_examples = []
-  end
+  library_examples = installed_library_path ? @arduino_cmd.library_examples(installed_library_path) : []
 
   # gather up all required boards for compilation so we can install them up front.
   # start with the "platforms to unittest" and add the examples

--- a/exe/arduino_ci_remote.rb
+++ b/exe/arduino_ci_remote.rb
@@ -229,7 +229,8 @@ def perform_compilation_tests(config)
     @arduino_cmd.install_local_library(Pathname.new("."))
   end
   if !installed_library_path
-    inform("No libraries installed") { "This probably indicates problems. Do you have a different/old library with the same name installed?" }
+    warning = "This probably indicates problems. Do you have a different/old library with the same name installed?"
+    inform("No libraries installed") { warning }
   elsif installed_library_path.exist?
     inform("Library installed at") { installed_library_path.to_s }
   else


### PR DESCRIPTION

## Background

For some time I have been having the source code in a directory with name on the form `projectname_somethingextra`, but just switched to using just `projectname`. This caused a problem because it turned out that there were a symlink an old version of the project in the .../arduino/sketchbook/libraries directory also with the name `projectname`. So the solution was to just remove the old stale symlink.

## Problem

The function `install_local_library` might sometimes return nil (which it did in the scenario described above), but the code in `perform_compilation_tests` does not handle that and instead crashes:

```shell
Installing library under test...                                               ✗
bundler: failed to load command: arduino_ci_remote.rb (.../bundle_install/ruby/2.5.0/bin/arduino_ci_remote.rb)
NoMethodError: undefined method `exist?' for nil:NilClass
  .../arduino/sketchbook/projectname/arduino_ci/exe/arduino_ci_remote.rb:231:in `perform_compilation_tests'
  .../arduino/sketchbook/projectname/arduino_ci/exe/arduino_ci_remote.rb:359:in `<top (required)>'
  .../arduino/sketchbook/projectname/bundle_install/ruby/2.5.0/bin/arduino_ci_remote.rb:23:in `load'
  .../arduino/sketchbook/projectname/bundle_install/ruby/2.5.0/bin/arduino_ci_remote.rb:23:in `<top (required)>'
```

With this pull request it fails more cleanly:

```shell
Installing library under test...                                               ✗
No libraries installed... This probably indicates problems. Do you have a different/old library with the same name installed?
Using pre-existing library...                                           SmartLCD
Skipping builds...                                        no libraries installed
Failures: 1
```
