### PR TITLE
Fixed nullptr and made some general test speedups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Added rspec sensitivity to the environment variable `$ARDUINO_CI_SELECT_CPP_TESTS=<glob>` (for `arduino_ci` gem hackers)
 
 ### Changed
 - `CiConfig::allowable_unittest_files` now uses `Pathname` to full effect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Added rspec sensitivity to the environment variable `$ARDUINO_CI_SELECT_CPP_TESTS=<glob>` (for `arduino_ci` gem hackers)
+- `assertNotNull()` and `assureNotNull()` C++ comparisons
 
 ### Changed
 - `CiConfig::allowable_unittest_files` now uses `Pathname` to full effect
+- `nullptr` now defined in its own class
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+- Assertions on `nullptr`
+- The defintion of `nullptr`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- `CiConfig::allowable_unittest_files` now uses `Pathname` to full effect
 
 ### Deprecated
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,9 @@ To speed up testing by targeting only the files you're working on, you can set s
 * `ARDUINO_CI_SKIP_SPLASH_SCREEN_RSPEC_TESTS`: if set, this will avoid any rspec test that calls the arduino executable (and as such, causes the splash screen to pop up).
 * `ARDUINO_CI_SKIP_RUBY_RSPEC_TESTS`: if set, this will skip all tests against ruby code (useful if you are not changing Ruby code).
 * `ARDUINO_CI_SKIP_CPP_RSPEC_TESTS`: if set, this will skip all tests against the `TestSomething` sample project (useful if you are not changing C++ code).
+* `ARDUINO_CI_SELECT_CPP_TESTS=<glob>`: if set, this will skip all C++ unit tests whose filenames don't match the provided glob (executed in the tests directory)
 
-You can set them to any value, they just have to be set.  Example usage:
+Example usage:
 
 ```shell
 ARDUINO_CI_SKIP_RUBY_RSPEC_TESTS=1 bundle exec rspec

--- a/SampleProjects/TestSomething/test/null.cpp
+++ b/SampleProjects/TestSomething/test/null.cpp
@@ -22,8 +22,30 @@ unittest(nothing)
 unittest(nullpointer)
 {
   int* myPointer = NULL;
+  int **notNullPointer = &myPointer;
+
   assertNull(myPointer);
   assertNull(nullptr);
+  assertEqual(myPointer, nullptr);
+  assertNotEqual(nullptr, notNullPointer);
+  assertNotNull(notNullPointer);
+}
+
+unittest(nullpointer_equal)
+{
+  int* myPointer = NULL;
+  int **notNullPointer = &myPointer;
+  assertEqual(nullptr, myPointer);
+  assertNotEqual(nullptr, notNullPointer);
+
+  assertLessOrEqual(nullptr, myPointer);
+  assertMoreOrEqual(myPointer, nullptr);
+  assertLessOrEqual(nullptr, notNullPointer);
+  assertMoreOrEqual(notNullPointer, nullptr);
+  assertLessOrEqual(myPointer, nullptr);
+  assertMoreOrEqual(notNullPointer, nullptr);
+  assertLess(nullptr, notNullPointer);
+  assertMore(notNullPointer, nullptr);
 }
 
 unittest_main()

--- a/cpp/arduino/Arduino.h
+++ b/cpp/arduino/Arduino.h
@@ -15,6 +15,7 @@ Where possible, variable names from the Arduino library are used to avoid confli
 #include "Stream.h"
 #include "HardwareSerial.h"
 #include "SPI.h"
+#include "Nullptr.h"
 
 typedef bool boolean;
 typedef uint8_t byte;
@@ -70,9 +71,5 @@ inline unsigned int makeWord(unsigned int w) { return w; }
 inline unsigned int makeWord(unsigned char h, unsigned char l) { return (h << 8) | l; }
 
 #define word(...) makeWord(__VA_ARGS__)
-
-
-// Define C++11 nullptr
-#define nullptr (std::nullptr_t)NULL
 
 

--- a/cpp/arduino/Nullptr.h
+++ b/cpp/arduino/Nullptr.h
@@ -1,0 +1,7 @@
+#pragma once
+
+// Define C++11 nullptr
+typedef void * my_nullptr_t;
+#define nullptr (my_nullptr_t)NULL
+
+inline std::ostream& operator << (std::ostream& out, const my_nullptr_t &np) { return out << "nullptr"; }

--- a/cpp/unittest/Assertion.h
+++ b/cpp/unittest/Assertion.h
@@ -39,6 +39,7 @@
 #define assertTrue(arg) assertEqual(true, arg)
 #define assertFalse(arg) assertEqual(false, arg)
 #define assertNull(arg) assertEqual((void*)NULL, (void*)arg)
+#define assertNotNull(arg) assertNotEqual((void*)NULL, (void*)arg)
 
 /** macro generates optional output and calls fail() followed by a return if false. */
 #define assureEqual(arg1,arg2)       assureOp("assureEqual","expected",arg1,compareEqual,"==","actual",arg2)
@@ -50,4 +51,5 @@
 #define assureTrue(arg) assureEqual(true, arg)
 #define assureFalse(arg) assureEqual(false, arg)
 #define assureNull(arg) assureEqual((void*)NULL, (void*)arg)
+#define assureNotNull(arg) assureNotEqual((void*)NULL, (void*)arg)
 

--- a/cpp/unittest/Compare.h
+++ b/cpp/unittest/Compare.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <avr/pgmspace.h>
 #include <WString.h>
+#include <Nullptr.h>
 
 template  < typename A, typename B > struct Compare
 {
@@ -897,10 +898,21 @@ template  < size_t N, size_t M > struct Compare<char [N],char [M]>
     return between(a,b) >= 0;
   } // moreOrEqual
 };
-template <typename A, typename B> int compareBetween(const A &a, const B &b) { return Compare<A,B>::between(a,b); }
-template <typename A, typename B> bool compareEqual(const A &a, const B &b) { return Compare<A,B>::equal(a,b); }
-template <typename A, typename B> bool compareNotEqual(const A &a, const B &b) { return Compare<A,B>::notEqual(a,b); }
-template <typename A, typename B> bool compareLess(const A &a, const B &b) { return Compare<A,B>::less(a,b); }
-template <typename A, typename B> bool compareMore(const A &a, const B &b) { return Compare<A,B>::more(a,b); }
-template <typename A, typename B> bool compareLessOrEqual(const A &a, const B &b) { return Compare<A,B>::lessOrEqual(a,b); }
-template <typename A, typename B> bool compareMoreOrEqual(const A &a, const B &b) { return Compare<A,B>::moreOrEqual(a,b); }
+
+// null pointer comparisons
+template <typename B> int  compareBetween(    const my_nullptr_t &a, const B &b) { return Compare<my_nullptr_t,B>::between(    a, b); }
+template <typename B> bool compareEqual(      const my_nullptr_t &a, const B &b) { return Compare<my_nullptr_t,B>::equal(      a, b); }
+template <typename B> bool compareNotEqual(   const my_nullptr_t &a, const B &b) { return Compare<my_nullptr_t,B>::notEqual(   a, b); }
+template <typename B> bool compareLess(       const my_nullptr_t &a, const B &b) { return Compare<my_nullptr_t,B>::less(       a, b); }
+template <typename B> bool compareMore(       const my_nullptr_t &a, const B &b) { return Compare<my_nullptr_t,B>::more(       a, b); }
+template <typename B> bool compareLessOrEqual(const my_nullptr_t &a, const B &b) { return Compare<my_nullptr_t,B>::lessOrEqual(a, b); }
+template <typename B> bool compareMoreOrEqual(const my_nullptr_t &a, const B &b) { return Compare<my_nullptr_t,B>::moreOrEqual(a, b); }
+
+// super general comparisons
+template <typename A, typename B> int  compareBetween(    const A &a, const B &b) { return Compare<A,B>::between(    a, b); }
+template <typename A, typename B> bool compareEqual(      const A &a, const B &b) { return Compare<A,B>::equal(      a, b); }
+template <typename A, typename B> bool compareNotEqual(   const A &a, const B &b) { return Compare<A,B>::notEqual(   a, b); }
+template <typename A, typename B> bool compareLess(       const A &a, const B &b) { return Compare<A,B>::less(       a, b); }
+template <typename A, typename B> bool compareMore(       const A &a, const B &b) { return Compare<A,B>::more(       a, b); }
+template <typename A, typename B> bool compareLessOrEqual(const A &a, const B &b) { return Compare<A,B>::lessOrEqual(a, b); }
+template <typename A, typename B> bool compareMoreOrEqual(const A &a, const B &b) { return Compare<A,B>::moreOrEqual(a, b); }

--- a/lib/arduino_ci/ci_config.rb
+++ b/lib/arduino_ci/ci_config.rb
@@ -287,17 +287,17 @@ module ArduinoCI
     end
 
     # Config allows select / reject (aka whitelist / blacklist) criteria.  Enforce on a dir
-    # @param paths [Array<String>] the initial set of test files
-    # @return [Array<String>] files that match the select/reject criteria
+    # @param paths [Array<Pathname>] the initial set of test files
+    # @return [Array<Pathname>] files that match the select/reject criteria
     def allowable_unittest_files(paths)
       return paths if @unittest_info[:testfiles].nil?
 
       ret = paths
       unless @unittest_info[:testfiles][:select].nil? || @unittest_info[:testfiles][:select].empty?
-        ret = ret.select { |p| unittest_info[:testfiles][:select].any? { |glob| File.fnmatch(glob, File.basename(p)) } }
+        ret.select! { |p| unittest_info[:testfiles][:select].any? { |glob| p.basename.fnmatch(glob) } }
       end
       unless @unittest_info[:testfiles][:reject].nil?
-        ret = ret.reject { |p| unittest_info[:testfiles][:reject].any? { |glob| File.fnmatch(glob, File.basename(p)) } }
+        ret.reject! { |p| unittest_info[:testfiles][:reject].any? { |glob| p.basename.fnmatch(glob) } }
       end
       ret
     end

--- a/spec/testsomething_unittests_spec.rb
+++ b/spec/testsomething_unittests_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe "TestSomething C++" do
     end
 
     test_files = config.allowable_unittest_files(cpp_library.test_files)
+
+    # filter the list based on a glob, if provided
+    unless ENV["ARDUINO_CI_SELECT_CPP_TESTS"].nil?
+      Dir.chdir(cpp_library.tests_dir) do
+        globbed = Pathname.glob(ENV["ARDUINO_CI_SELECT_CPP_TESTS"])
+        test_files.select! { |p| globbed.include?(p.basename) }
+      end
+    end
     test_files.each do |path|
       tfn = File.basename(path)
 


### PR DESCRIPTION
## Highlights from `CHANGELOG.md`
### Added
- Added rspec sensitivity to the environment variable `$ARDUINO_CI_SELECT_CPP_TESTS=<glob>` (for `arduino_ci` gem hackers)
- `assertNotNull()` and `assureNotNull()` C++ comparisons

### Changed
- `CiConfig::allowable_unittest_files` now uses `Pathname` to full effect
- `nullptr` now defined in its own class

### Fixed
- Assertions on `nullptr`
- The defintion of `nullptr`

* See CHANGELOG.md for more


## Issues Fixed

* Fixes #102
