### PR TITLE
Correction for issue #102

### DIFF
--- a/SampleProjects/DoSomething/do-something.cpp
+++ b/SampleProjects/DoSomething/do-something.cpp
@@ -4,3 +4,19 @@ int doSomething(void) {
   millis();  // this line is only here to test that we're able to refer to the builtins
   return 4;
 };
+
+static const struct something table[] = {
+	{ 1, "abc" },
+	{ 2, "xyz" },
+	{ 4, "123" },
+};
+
+const struct something *findSomething(int id) {
+	for (unsigned int i = 0; i < 3; i++) {
+		if (table[i].id == id) {
+			return &table[i];
+		}
+	}
+	return nullptr;
+}
+

--- a/SampleProjects/DoSomething/do-something.h
+++ b/SampleProjects/DoSomething/do-something.h
@@ -1,3 +1,11 @@
 #pragma once
 #include <Arduino.h>
 int doSomething(void);
+
+struct something {
+	int id;
+	const char *text;
+};
+
+const struct something *findSomething(int id);
+

--- a/SampleProjects/DoSomething/test/README.md
+++ b/SampleProjects/DoSomething/test/README.md
@@ -1,0 +1,3 @@
+# Naming convention #
+
+Files in this directory is expected to have names that either contains "bad" if it is expected to fail or "good" if it is expected to pass.

--- a/SampleProjects/DoSomething/test/good-find-something.cpp
+++ b/SampleProjects/DoSomething/test/good-find-something.cpp
@@ -1,0 +1,21 @@
+#include <ArduinoUnitTests.h>
+
+#include "do-something.h"
+
+unittest(find_something_that_exists)
+{
+  const struct something *result;
+  result = findSomething(1);
+  assertNotNull(result);
+  assertEqual("abc", result->text);
+}
+
+unittest(find_something_that_does_not_exists)
+{
+  const struct something *result;
+  result = findSomething(1000);
+  assertNull(result);
+}
+
+unittest_main()
+

--- a/spec/cpp_library_spec.rb
+++ b/spec/cpp_library_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe ArduinoCI::CppLibrary do
       dosomething_test_files = [
         "DoSomething/test/good-null.cpp",
         "DoSomething/test/good-library.cpp",
+        "DoSomething/test/good-find-something.cpp",
         "DoSomething/test/bad-null.cpp",
       ].map { |f| Pathname.new(f) }
       relative_paths = cpp_library.test_files.map { |f| get_relative_dir(f) }


### PR DESCRIPTION
Including `Nullptr.h` in `Arduino.h` breaks code that uses `nullptr`. The nullptr define in `Nullptr.h` is only applicable for use for the compare functions and should only be included when compiling the unit test files.