### PR TITLE
Mock for sleep and wdt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Proper `ostream operator <<` for `nullptr`
 - Proper comparison operations fro `nullptr`
+- Mocks for avr/sleep.h and avr/wdt.h
+- Definitions for ISR and ADCSRA
 
 ### Changed
 - `Compare.h` heavily refactored to use a smallish macro

--- a/SampleProjects/DoSomething/examples/AvrSleepInterrupt/.arduino-ci.yaml
+++ b/SampleProjects/DoSomething/examples/AvrSleepInterrupt/.arduino-ci.yaml
@@ -1,0 +1,11 @@
+compile:
+  libraries: ~
+  platforms:
+    - uno
+    - leonardo
+
+unittest:
+  libraries: ~
+  platforms:
+    - uno
+    - leonardo

--- a/SampleProjects/DoSomething/examples/AvrSleepInterrupt/AvrSleepInterrupt.ino
+++ b/SampleProjects/DoSomething/examples/AvrSleepInterrupt/AvrSleepInterrupt.ino
@@ -1,0 +1,27 @@
+#include <avr/sleep.h>
+
+#define BUTTON_INT_PIN 2
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("start");
+  delay(200);
+  pinMode(BUTTON_INT_PIN, INPUT_PULLUP);
+  attachInterrupt(digitalPinToInterrupt(BUTTON_INT_PIN), isrButtonTrigger, FALLING);
+}
+
+void loop() {
+  // sleep unti an interrupt occurs
+  sleep_enable(); // enables the sleep bit, a safety pin
+  set_sleep_mode(SLEEP_MODE_PWR_DOWN);
+  sleep_cpu(); // here the device is actually put to sleep
+  sleep_disable(); // disables the sleep bit, a safety pin
+
+  Serial.println("interrupt");
+  delay(200);
+}
+
+void isrButtonTrigger() {
+  // nothing to do, wakes up the CPU
+}
+

--- a/SampleProjects/DoSomething/examples/AvrWdtReset/.arduino-ci.yaml
+++ b/SampleProjects/DoSomething/examples/AvrWdtReset/.arduino-ci.yaml
@@ -1,0 +1,11 @@
+compile:
+  libraries: ~
+  platforms:
+    - uno
+    - leonardo
+
+unittest:
+  libraries: ~
+  platforms:
+    - uno
+    - leonardo

--- a/SampleProjects/DoSomething/examples/AvrWdtReset/AvrWdtReset.ino
+++ b/SampleProjects/DoSomething/examples/AvrWdtReset/AvrWdtReset.ino
@@ -1,0 +1,29 @@
+#include <avr/wdt.h>
+
+void setup() {
+  pinMode(LED_BUILTIN, OUTPUT);
+  digitalWrite(LED_BUILTIN, LOW);
+
+  wdt_enable(WDTO_4S);
+  // First timeout executes interrupt, second does reset.
+  // So first LED 4s off
+  // then LED 4s on
+  // then reset CPU and start again
+  WDTCSR |= (1 << WDIE);
+}
+
+void loop() {
+  // the program is alive...for now.
+  wdt_reset();
+
+  while (1)
+    ; // do nothing. the program will lockup here.
+
+  // Can not get here
+}
+
+ISR (WDT_vect) {
+  // WDIE & WDIF is cleared in hardware upon entering this ISR
+  digitalWrite(LED_BUILTIN, HIGH);
+}
+

--- a/SampleProjects/TestSomething/test/adc.cpp
+++ b/SampleProjects/TestSomething/test/adc.cpp
@@ -1,0 +1,10 @@
+#include <ArduinoUnitTests.h>
+#include <Arduino.h>
+
+unittest(check_ADCSRA_read_write) {
+  ADCSRA = 123;
+
+  assertEqual(123, ADCSRA);
+}
+
+unittest_main()

--- a/SampleProjects/TestSomething/test/interrupts.cpp
+++ b/SampleProjects/TestSomething/test/interrupts.cpp
@@ -23,6 +23,11 @@ unittest(interrupt_attachment) {
   assertFalse(state->interrupt[0].attached);
 }
 
-
+// Just check if declaration compiles.
+// WDT_vect defines the interrupt of the watchdog timer
+// if configured accordinly.
+// See avr/interrupt.h
+ISR (WDT_vect) {
+}
 
 unittest_main()

--- a/SampleProjects/TestSomething/test/isr_declaration.cpp
+++ b/SampleProjects/TestSomething/test/isr_declaration.cpp
@@ -1,6 +1,7 @@
 #include <ArduinoUnitTests.h>
 #include <Arduino.h>
 
+// just check if declaration compiles
 ISR (WDT_vect) {
 }
 

--- a/SampleProjects/TestSomething/test/isr_declaration.cpp
+++ b/SampleProjects/TestSomething/test/isr_declaration.cpp
@@ -1,8 +1,0 @@
-#include <ArduinoUnitTests.h>
-#include <Arduino.h>
-
-// just check if declaration compiles
-ISR (WDT_vect) {
-}
-
-unittest_main()

--- a/SampleProjects/TestSomething/test/isr_declaration.cpp
+++ b/SampleProjects/TestSomething/test/isr_declaration.cpp
@@ -1,0 +1,7 @@
+#include <ArduinoUnitTests.h>
+#include <Arduino.h>
+
+ISR (WDT_vect) {
+}
+
+unittest_main()

--- a/SampleProjects/TestSomething/test/sleep.cpp
+++ b/SampleProjects/TestSomething/test/sleep.cpp
@@ -1,0 +1,65 @@
+#include <ArduinoUnitTests.h>
+#include <avr/sleep.h>
+
+GodmodeState* state = GODMODE();
+
+unittest(sleep_enable) {
+  state->reset();
+  assertFalse(state->sleep.sleep_enable);
+  assertEqual(0, state->sleep.sleep_enable_count);
+
+  sleep_enable();
+
+  assertTrue(state->sleep.sleep_enable);
+  assertEqual(1, state->sleep.sleep_enable_count);
+}
+
+unittest(sleep_disable) {
+  state->reset();
+  assertEqual(0, state->sleep.sleep_disable_count);
+
+  sleep_disable();
+
+  assertFalse(state->sleep.sleep_enable);
+  assertEqual(1, state->sleep.sleep_disable_count);
+}
+
+unittest(set_sleep_mode) {
+  state->reset();
+  assertEqual(0, state->sleep.sleep_mode);
+
+  set_sleep_mode(SLEEP_MODE_PWR_DOWN);
+
+  assertEqual(SLEEP_MODE_PWR_DOWN, state->sleep.sleep_mode);
+}
+
+unittest(sleep_bod_disable) {
+  state->reset();
+  assertEqual(0, state->sleep.sleep_bod_disable_count);
+
+  sleep_bod_disable();
+
+  assertEqual(1, state->sleep.sleep_bod_disable_count);
+}
+
+unittest(sleep_cpu) {
+  state->reset();
+  assertEqual(0, state->sleep.sleep_cpu_count);
+
+  sleep_cpu();
+
+  assertEqual(1, state->sleep.sleep_cpu_count);
+}
+
+unittest(sleep_mode) {
+  state->reset();
+  assertEqual(0, state->sleep.sleep_mode_count);
+
+  sleep_mode();
+
+  assertEqual(1, state->sleep.sleep_mode_count);
+  assertEqual(1, state->sleep.sleep_enable_count);
+  assertEqual(1, state->sleep.sleep_disable_count);
+}
+
+unittest_main()

--- a/SampleProjects/TestSomething/test/wdt.cpp
+++ b/SampleProjects/TestSomething/test/wdt.cpp
@@ -1,0 +1,41 @@
+#include <ArduinoUnitTests.h>
+#include <avr/wdt.h>
+
+GodmodeState* state = GODMODE();
+
+unittest(taskWdtEnable_checkTimeout) {
+  state->reset();
+  assertEqual(0, state->wdt.timeout);
+
+  wdt_enable(WDTO_1S);
+
+  assertTrue(state->wdt.wdt_enable);
+  assertEqual(WDTO_1S, state->wdt.timeout);
+  assertEqual(1, state->wdt.wdt_enable_count);
+}
+
+unittest(taskWdtEnableDisable) {
+  state->reset();
+  assertEqual(0, state->wdt.wdt_enable_count);
+
+  wdt_enable(WDTO_1S);
+
+  assertTrue(state->wdt.wdt_enable);
+  assertEqual(1, state->wdt.wdt_enable_count);
+
+  wdt_disable();
+
+  assertFalse(state->wdt.wdt_enable);
+  assertEqual(1, state->wdt.wdt_enable_count);
+}
+
+unittest(wdt_reset) {
+  state->reset();
+  assertEqual(0, state->wdt.wdt_reset_count);
+
+  wdt_reset();
+
+  assertEqual(1, state->wdt.wdt_reset_count);
+}
+
+unittest_main()

--- a/cpp/arduino/Arduino.h
+++ b/cpp/arduino/Arduino.h
@@ -24,6 +24,8 @@ typedef uint8_t byte;
 // Math and Trig
 #include "AvrMath.h"
 
+#include <avr/interrupt.h>
+
 #include "Godmode.h"
 
 

--- a/cpp/arduino/Arduino.h
+++ b/cpp/arduino/Arduino.h
@@ -24,6 +24,7 @@ typedef uint8_t byte;
 // Math and Trig
 #include "AvrMath.h"
 
+#include "AvrAdc.h"
 #include <avr/interrupt.h>
 
 #include "Godmode.h"

--- a/cpp/arduino/Arduino.h
+++ b/cpp/arduino/Arduino.h
@@ -25,7 +25,7 @@ typedef uint8_t byte;
 #include "AvrMath.h"
 
 #include "AvrAdc.h"
-#include <avr/interrupt.h>
+#include "avr/interrupt.h"
 
 #include "Godmode.h"
 

--- a/cpp/arduino/AvrAdc.cpp
+++ b/cpp/arduino/AvrAdc.cpp
@@ -1,0 +1,4 @@
+#include "AvrAdc.h"
+
+// mock storage to allow access to ADCSRA
+unsigned char sfr_store;

--- a/cpp/arduino/AvrAdc.h
+++ b/cpp/arduino/AvrAdc.h
@@ -1,5 +1,9 @@
 #pragma once
 
-// mock storage to allow access to ADCSRA
+// ADCSRA is defined in the CPU specific header files
+// like iom328p.h.
+// It is liked to _SFR_MEM8 what does not exists in the test environment.
+// Therefore we define _SFR_MEM8 here and provide it a storage
+// location so that the test code can read/write on it.
 extern unsigned char sfr_store;
 #define _SFR_MEM8(mem_addr) sfr_store

--- a/cpp/arduino/AvrAdc.h
+++ b/cpp/arduino/AvrAdc.h
@@ -1,0 +1,8 @@
+#ifndef _AVR_ADC_H_
+#define _AVR_ADC_H_
+
+// mock storage to allow access to ADCSRA
+extern unsigned char sfr_store;
+#define _SFR_MEM8(mem_addr) sfr_store
+
+#endif // _AVR_ADC_H_

--- a/cpp/arduino/AvrAdc.h
+++ b/cpp/arduino/AvrAdc.h
@@ -1,8 +1,5 @@
-#ifndef _AVR_ADC_H_
-#define _AVR_ADC_H_
+#pragma once
 
 // mock storage to allow access to ADCSRA
 extern unsigned char sfr_store;
 #define _SFR_MEM8(mem_addr) sfr_store
-
-#endif // _AVR_ADC_H_

--- a/cpp/arduino/Godmode.h
+++ b/cpp/arduino/Godmode.h
@@ -53,6 +53,14 @@ class GodmodeState {
     unsigned int sleep_bod_disable_count = 0;
   };
 
+  struct WdtDef {
+    bool wdt_enable = false;
+    unsigned char timeout = 0;
+    unsigned int wdt_enable_count = 0;
+    unsigned int wdt_disable_count = 0;
+    unsigned int wdt_reset_count = 0;
+  };
+
   public:
     unsigned long micros;
     unsigned long seed;
@@ -63,6 +71,7 @@ class GodmodeState {
     struct InterruptDef interrupt[MOCK_PINS_COUNT]; // not sure how to get actual number
     struct PortDef spi;
     struct SleepDef sleep;
+    struct WdtDef wdt;
 
     void resetPins() {
       for (int i = 0; i < MOCK_PINS_COUNT; ++i) {
@@ -106,6 +115,14 @@ class GodmodeState {
       sleep.sleep_bod_disable_count = 0;
     }
 
+    void resetWdt() {
+      wdt.wdt_enable = false;
+      wdt.timeout = 0;
+      wdt.wdt_enable_count = 0;
+      wdt.wdt_disable_count = 0;
+      wdt.wdt_reset_count = 0;
+    }
+
     void reset() {
       resetClock();
       resetPins();
@@ -113,6 +130,7 @@ class GodmodeState {
       resetPorts();
       resetSPI();
       resetSleep();
+      resetWdt();
       seed = 1;
     }
 
@@ -136,7 +154,7 @@ int analogRead(uint8_t);
 void analogWrite(uint8_t, int);
 #define analogReadResolution(...) _NOP()
 #define analogWriteResolution(...) _NOP()
-void attachInterrupt(uint8_t interrupt, void ISR(void), uint8_t mode);
+void attachInterrupt(uint8_t interrupt, void isr(void), uint8_t mode);
 void detachInterrupt(uint8_t interrupt);
 
 // TODO: issue #26 to track the commanded state here

--- a/cpp/arduino/Godmode.h
+++ b/cpp/arduino/Godmode.h
@@ -43,6 +43,16 @@ class GodmodeState {
     uint8_t mode;
   };
 
+  struct SleepDef {
+    bool sleep_enable = false;
+    unsigned int sleep_enable_count = 0;
+    unsigned int sleep_disable_count = 0;
+    unsigned char sleep_mode = 0;
+    unsigned int sleep_cpu_count = 0;
+    unsigned int sleep_mode_count = 0;
+    unsigned int sleep_bod_disable_count = 0;
+  };
+
   public:
     unsigned long micros;
     unsigned long seed;
@@ -52,6 +62,7 @@ class GodmodeState {
     struct PortDef serialPort[NUM_SERIAL_PORTS];
     struct InterruptDef interrupt[MOCK_PINS_COUNT]; // not sure how to get actual number
     struct PortDef spi;
+    struct SleepDef sleep;
 
     void resetPins() {
       for (int i = 0; i < MOCK_PINS_COUNT; ++i) {
@@ -85,12 +96,23 @@ class GodmodeState {
       spi.readDelayMicros = 0;
     }
 
+    void resetSleep() {
+      sleep.sleep_enable = false;
+      sleep.sleep_enable_count = 0;
+      sleep.sleep_disable_count = 0;
+      sleep.sleep_mode = 0;
+      sleep.sleep_cpu_count = 0;
+      sleep.sleep_mode_count = 0;
+      sleep.sleep_bod_disable_count = 0;
+    }
+
     void reset() {
       resetClock();
       resetPins();
       resetInterrupts();
       resetPorts();
       resetSPI();
+      resetSleep();
       seed = 1;
     }
 

--- a/cpp/arduino/avr/interrupt.h
+++ b/cpp/arduino/avr/interrupt.h
@@ -1,10 +1,7 @@
-#ifndef _AVR_INTERRUPT_H_
-#define _AVR_INTERRUPT_H_
+#pragma once
 
 // allows the production code to define an ISR method
 #define _VECTOR(N) __vector_ ## N
 #define ISR(vector, ...)            \
      extern "C" void vector (void)  __VA_ARGS__; \
      void vector (void)
-
-#endif // _AVR_INTERRUPT_H_

--- a/cpp/arduino/avr/interrupt.h
+++ b/cpp/arduino/avr/interrupt.h
@@ -7,4 +7,4 @@
      extern "C" void vector (void)  __VA_ARGS__; \
      void vector (void)
 
-#endif
+#endif // _AVR_INTERRUPT_H_

--- a/cpp/arduino/avr/interrupt.h
+++ b/cpp/arduino/avr/interrupt.h
@@ -1,0 +1,10 @@
+#ifndef _AVR_INTERRUPT_H_
+#define _AVR_INTERRUPT_H_
+
+#define _VECTOR(N) __vector_ ## N
+
+#define ISR(vector, ...)            \
+     extern "C" void vector (void)  __VA_ARGS__; \
+     void vector (void)
+
+#endif

--- a/cpp/arduino/avr/interrupt.h
+++ b/cpp/arduino/avr/interrupt.h
@@ -1,6 +1,14 @@
+/*
+   This header file defines the macros required for the production
+   code for AVR CPUs to declare ISRs in the test environment.
+   See for more details
+   https://www.nongnu.org/avr-libc/user-manual/group__avr__interrupts.html
+*/
 #pragma once
 
-// allows the production code to define an ISR method
+// Allows the production code to define an ISR method.
+// These definitions come from the original avr/interrupt.h file
+// https://www.nongnu.org/avr-libc/user-manual/interrupt_8h_source.html
 #define _VECTOR(N) __vector_ ## N
 #define ISR(vector, ...)            \
      extern "C" void vector (void)  __VA_ARGS__; \

--- a/cpp/arduino/avr/interrupt.h
+++ b/cpp/arduino/avr/interrupt.h
@@ -1,8 +1,8 @@
 #ifndef _AVR_INTERRUPT_H_
 #define _AVR_INTERRUPT_H_
 
+// allows the production code to define an ISR method
 #define _VECTOR(N) __vector_ ## N
-
 #define ISR(vector, ...)            \
      extern "C" void vector (void)  __VA_ARGS__; \
      void vector (void)

--- a/cpp/arduino/avr/sleep.h
+++ b/cpp/arduino/avr/sleep.h
@@ -1,5 +1,4 @@
-#ifndef _AVR_SLEEP_H_
-#define _AVR_SLEEP_H_
+#pragma once
 
 #include <Godmode.h>
 
@@ -36,5 +35,3 @@ void sleep_mode() {
   godmode->sleep.sleep_mode_count++;
   sleep_disable();
 }
-
-#endif /* _AVR_SLEEP_H_ */

--- a/cpp/arduino/avr/sleep.h
+++ b/cpp/arduino/avr/sleep.h
@@ -1,3 +1,8 @@
+/*
+   This header file defines the functionality to put AVR CPUs to sleep mode.
+   For details see
+   https://www.nongnu.org/avr-libc/user-manual/group__avr__sleep.html
+*/
 #pragma once
 
 #include <Godmode.h>

--- a/cpp/arduino/avr/sleep.h
+++ b/cpp/arduino/avr/sleep.h
@@ -37,6 +37,7 @@ void sleep_mode() {
   sleep_disable();
 }
 
+// mock storage to allow access to ADCSRA
 unsigned char sfr_store;
 #define _SFR_MEM8(mem_addr) sfr_store
 

--- a/cpp/arduino/avr/sleep.h
+++ b/cpp/arduino/avr/sleep.h
@@ -37,8 +37,4 @@ void sleep_mode() {
   sleep_disable();
 }
 
-// mock storage to allow access to ADCSRA
-unsigned char sfr_store;
-#define _SFR_MEM8(mem_addr) sfr_store
-
 #endif /* _AVR_SLEEP_H_ */

--- a/cpp/arduino/avr/sleep.h
+++ b/cpp/arduino/avr/sleep.h
@@ -1,0 +1,43 @@
+#ifndef _AVR_SLEEP_H_
+#define _AVR_SLEEP_H_
+
+#include <Godmode.h>
+
+void sleep_enable() {
+  GodmodeState* godmode = GODMODE();
+  godmode->sleep.sleep_enable = true;
+  godmode->sleep.sleep_enable_count++;
+}
+
+void sleep_disable() {
+  GodmodeState* godmode = GODMODE();
+  godmode->sleep.sleep_enable = false;
+  godmode->sleep.sleep_disable_count++;
+}
+
+void set_sleep_mode(unsigned char mode) {
+  GodmodeState* godmode = GODMODE();
+  godmode->sleep.sleep_mode = mode;
+}
+
+void sleep_bod_disable() {
+  GodmodeState* godmode = GODMODE();
+  godmode->sleep.sleep_bod_disable_count++;
+}
+
+void sleep_cpu() {
+  GodmodeState* godmode = GODMODE();
+  godmode->sleep.sleep_cpu_count++;
+}
+
+void sleep_mode() {
+  GodmodeState* godmode = GODMODE();
+  sleep_enable();
+  godmode->sleep.sleep_mode_count++;
+  sleep_disable();
+}
+
+unsigned char sfr_store;
+#define _SFR_MEM8(mem_addr) sfr_store
+
+#endif /* _AVR_SLEEP_H_ */

--- a/cpp/arduino/avr/wdt.h
+++ b/cpp/arduino/avr/wdt.h
@@ -1,5 +1,4 @@
-#ifndef _AVR_WDT_H_
-#define _AVR_WDT_H_
+#pragma once
 
 #include <Godmode.h>
 
@@ -31,5 +30,3 @@ void wdt_reset() {
   GodmodeState* godmode = GODMODE();
   godmode->wdt.wdt_reset_count++;
 }
-
-#endif /* _AVR_WDT_H_ */

--- a/cpp/arduino/avr/wdt.h
+++ b/cpp/arduino/avr/wdt.h
@@ -1,7 +1,6 @@
 #ifndef _AVR_WDT_H_
 #define _AVR_WDT_H_
 
-#include <avr/interrupt.h>
 #include <Godmode.h>
 
 #define WDTO_15MS   0

--- a/cpp/arduino/avr/wdt.h
+++ b/cpp/arduino/avr/wdt.h
@@ -1,3 +1,9 @@
+/*
+   This header file defines the funtionality to use the watchdog timer on
+   AVR CPUs.
+   For details see
+   https://www.nongnu.org/avr-libc/user-manual/group__avr__watchdog.html
+*/
 #pragma once
 
 #include <Godmode.h>

--- a/cpp/arduino/avr/wdt.h
+++ b/cpp/arduino/avr/wdt.h
@@ -1,0 +1,36 @@
+#ifndef _AVR_WDT_H_
+#define _AVR_WDT_H_
+
+#include <avr/interrupt.h>
+#include <Godmode.h>
+
+#define WDTO_15MS   0
+#define WDTO_30MS   1
+#define WDTO_60MS   2
+#define WDTO_120MS  3
+#define WDTO_250MS  4
+#define WDTO_500MS  5
+#define WDTO_1S     6
+#define WDTO_2S     7
+#define WDTO_4S     8
+#define WDTO_8S     9
+
+void wdt_enable(unsigned char timeout) {
+  GodmodeState* godmode = GODMODE();
+  godmode->wdt.wdt_enable = true;
+  godmode->wdt.timeout = timeout;
+  godmode->wdt.wdt_enable_count++;
+}
+
+void wdt_disable() {
+  GodmodeState* godmode = GODMODE();
+  godmode->wdt.wdt_enable = false;
+  godmode->wdt.wdt_disable_count++;
+}
+
+void wdt_reset() {
+  GodmodeState* godmode = GODMODE();
+  godmode->wdt.wdt_reset_count++;
+}
+
+#endif /* _AVR_WDT_H_ */


### PR DESCRIPTION
This is my first pull request to contribute code to this project. Constructive feedback is therefore very welcome to allow the project to develop consistently.

- add `avr/sleep.h` with calls to `GodmodeState`
- add `avr/wdt.h` with calls to `GodmodeState`
- add new structs `SleepDef` and `WdtDef`
- add new structs in `GodmodeState` and reset them on `reset()`
- add interrupt `define` for ISR to allow the production code to specify an ISR for wdt
- rename existing `ISR` in function `attachInterrupt()` as it conflicts with AVR's `ISR`
- add storage location to allow usage of `ADCSRA`
- add tests for the new functionality
