### PR TITLE
Additional board definitions for #89

### DIFF
--- a/misc/default.yml
+++ b/misc/default.yml
@@ -92,6 +92,15 @@ platforms:
       defines:
       warnings:
       flags:
+  mega1280:
+    board: arduino:avr:mega:cpu=atmega1280
+    package: arduino:avr
+    gcc:
+      features:
+      defines:
+        - __AVR_ATmega1280__
+      warnings:
+      flags:
   mega2560:
     board: arduino:avr:mega:cpu=atmega2560
     package: arduino:avr

--- a/misc/default.yml
+++ b/misc/default.yml
@@ -14,7 +14,16 @@ packages:
     url: https://dl.espressif.com/dl/package_esp32_index.json
 
 platforms:
-
+  
+  nano:
+    board: arduino:avr:nano
+    package: arduino:avr
+    gcc:
+      features:
+      defines:
+        - __AVR_ATmega328__
+      warnings:
+      flags:
   uno:
     board: arduino:avr:uno
     package: arduino:avr
@@ -30,7 +39,7 @@ platforms:
     gcc:
       features:
       defines:
-        - __AVR_ATmega328__
+        - __AVR_ATSAM3X8E__
       warnings:
       flags:
   zero:
@@ -86,6 +95,14 @@ platforms:
       flags:
   m4:
     board: adafruit:samd:adafruit_metro_m4
+    package: adafruit:samd
+    gcc:
+      features:
+      defines:
+      warnings:
+      flags:
+  grand_central_m4:
+    board: adafruit:samd:adafruit_grand_central_m4
     package: adafruit:samd
     gcc:
       features:

--- a/misc/default.yml
+++ b/misc/default.yml
@@ -15,7 +15,16 @@ packages:
 
 platforms:
   
-  nano:
+  nano_v2:
+    board: arduino:avr:nano
+    package: arduino:avr
+    gcc:
+      features:
+      defines:
+        - __AVR_ATmega168__
+      warnings:
+      flags:
+  nano_v3: &nano_p
     board: arduino:avr:nano
     package: arduino:avr
     gcc:
@@ -24,6 +33,7 @@ platforms:
         - __AVR_ATmega328__
       warnings:
       flags:
+  nano: *nano_p
   uno:
     board: arduino:avr:uno
     package: arduino:avr
@@ -39,7 +49,7 @@ platforms:
     gcc:
       features:
       defines:
-        - __AVR_ATSAM3X8E__
+        - __ATSAM3X8E__
       warnings:
       flags:
   zero:


### PR DESCRIPTION
## Highlights
Added entries for additional boards:
  * Nano (defaults to v3, includes v2 as well)
  * Mega1280
  * Adafruit Grand Central M4 Express

## Issues Fixed
Changed processor used for Arduino due from atmega/avr to atmel sam

## Notes
* No action has been taken as of yet to expose additional analog pins on Nano
* No action has been take to expose additional features of the Grand Central beyond the standard M4 at this time