### PR TITLE
include ability to exclude certain directories from compilation

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -112,8 +112,16 @@ For your unit tests, in addition to setting specific libraries and platforms, yo
 
 Filtering your unit tests may help speed up targeted testing locally, but it is intended primarily as a means to temporarily disable tests between individual commits.
 
+Furthermore, you can filter the files that will be included in the compilation step by specifying `exclude_dirs`. All cpp and header files in those directories will not be included in the compilation step, before the unittests are run.
+
 ```yaml
 unittest:
+
+  # Exclude these directories from compilation
+  exclude_dirs:
+    - someDirectory
+    - someOtherDirectory
+
   # Perform unit tests with these compilers (these are the binaries that will be called via the shell)
   compilers:
     - g++      # default

--- a/SampleProjects/TestSomething/.arduino-ci.yml
+++ b/SampleProjects/TestSomething/.arduino-ci.yml
@@ -1,4 +1,6 @@
 unittest:
+  exclude_dirs:
+    - excludeThis
   platforms:
     - uno
     - due

--- a/SampleProjects/TestSomething/excludeThis/exclude-this.cpp
+++ b/SampleProjects/TestSomething/excludeThis/exclude-this.cpp
@@ -1,0 +1,10 @@
+#include "test-something.h"
+int testSomething(void) {
+  millis();  // this line is only here to test that we're able to refer to the builtins
+  return 4;
+};
+
+int* aNullPointer(void) {
+  int* ret = nullptr;
+  return ret;
+}

--- a/SampleProjects/TestSomething/excludeThis/exclude-this.h
+++ b/SampleProjects/TestSomething/excludeThis/exclude-this.h
@@ -1,0 +1,4 @@
+#pragma once
+#include <Arduino.h>
+int testSomething(void);
+int *aNullPointer(void);

--- a/exe/arduino_ci_remote.rb
+++ b/exe/arduino_ci_remote.rb
@@ -173,7 +173,7 @@ def perform_unit_tests(file_config)
     return
   end
   config = file_config.with_override_config(@cli_options[:ci_config])
-  cpp_library = ArduinoCI::CppLibrary.new(Pathname.new("."), @arduino_cmd.lib_dir)
+  cpp_library = ArduinoCI::CppLibrary.new(Pathname.new("."), @arduino_cmd.lib_dir, config.exclude_dirs)
 
   # check GCC
   compilers = config.compilers_to_use

--- a/lib/arduino_ci/ci_config.rb
+++ b/lib/arduino_ci/ci_config.rb
@@ -28,6 +28,7 @@ UNITTEST_SCHEMA = {
   compilers: Array,
   platforms: Array,
   libraries: Array,
+  exclude_dirs: Array,
   testfiles: {
     select: Array,
     reject: Array,
@@ -254,6 +255,14 @@ module ArduinoCI
       return [] if @unittest_info[:compilers].nil?
 
       @unittest_info[:compilers]
+    end
+
+    # paths to exclude all files in for building and unitttests
+    # @return [Array<String>] The directories (relative to base dir) to exclude
+    def exclude_dirs
+      return [] if @unittest_info[:exclude_dirs].nil?
+
+      @unittest_info[:exclude_dirs]
     end
 
     # platforms to build [the examples on]

--- a/lib/arduino_ci/cpp_library.rb
+++ b/lib/arduino_ci/cpp_library.rb
@@ -37,11 +37,14 @@ module ArduinoCI
 
     # @param base_dir [Pathname] The path to the library being tested
     # @param arduino_lib_dir [Pathname] The path to the libraries directory
-    def initialize(base_dir, arduino_lib_dir)
+    def initialize(base_dir, arduino_lib_dir, exclude_dirs = [])
       raise ArgumentError, 'base_dir is not a Pathname' unless base_dir.is_a? Pathname
       raise ArgumentError, 'arduino_lib_dir is not a Pathname' unless arduino_lib_dir.is_a? Pathname
+      raise ArgumentError, 'exclude_dir is not an array of Pathnames' unless exclude_dirs.is_a?(Array) &&
+                                                                             exclude_dirs.each { |p| p.is_a? Pathname }
 
       @base_dir = base_dir
+      @exclude_dirs = exclude_dirs
       @arduino_lib_dir = arduino_lib_dir.expand_path
       @artifacts = []
       @last_err = ""
@@ -115,6 +118,19 @@ module ArduinoCI
       false
     end
 
+    # Guess whether a file is part of any @excludes_dir dir (indicating library compilation should ignore it).
+    #
+    # @param path [Pathname] The path to check
+    # @return [bool]
+    def in_exclude_dir?(path)
+      # we could do this but some rubies don't return an enumerator for ascend
+      # path.ascend.any? { |part| tests_dir_aliases.include?(part) }
+      path.ascend do |part|
+        return true if exclude_dir.any? { |p| p.realpath == part }
+      end
+      false
+    end
+
     # Check whether libasan (and by extension -fsanitizer=address) is supported
     #
     # This requires compilation of a sample program, and will be cached
@@ -150,7 +166,7 @@ module ArduinoCI
     # CPP files that are part of the project library under test
     # @return [Array<Pathname>]
     def cpp_files
-      cpp_files_in(@base_dir).reject { |p| vendor_bundle?(p) || in_tests_dir?(p) }
+      cpp_files_in(@base_dir).reject { |p| vendor_bundle?(p) || in_tests_dir?(p) || in_exclude_dir?(p) }
     end
 
     # CPP files that are part of the arduino mock library we're providing
@@ -172,6 +188,12 @@ module ArduinoCI
       arduino_library_src_dirs(aux_libraries).map { |d| cpp_files_in(d) }.flatten.uniq
     end
 
+    # Returns the Pathnames for all paths to exclude from testing and compilation
+    # @return [Array<Pathname>]
+    def exclude_dir
+      @exclude_dirs.map { |p| Pathname.new(@base_dir) + p }.select(&:exist?)
+    end
+
     # The directory where we expect to find unit test defintions provided by the user
     # @return [Pathname]
     def tests_dir
@@ -190,7 +212,8 @@ module ArduinoCI
       real = @base_dir.realpath
       all_files = Find.find(real).map { |f| Pathname.new(f) }.reject(&:directory?)
       unbundled = all_files.reject { |path| vendor_bundle?(path) }
-      files = unbundled.select { |path| HPP_EXTENSIONS.include?(path.extname.downcase) }
+      unexcluded = unbundled.reject { |path| in_exclude_dir?(path) }
+      files = unexcluded.select { |path| HPP_EXTENSIONS.include?(path.extname.downcase) }
       files.map(&:dirname).uniq
     end
 

--- a/spec/testsomething_unittests_spec.rb
+++ b/spec/testsomething_unittests_spec.rb
@@ -13,7 +13,9 @@ end
 RSpec.describe "TestSomething C++" do
   next if skip_cpp_tests
   cpp_lib_path = sampleproj_path + "TestSomething"
-  cpp_library = ArduinoCI::CppLibrary.new(cpp_lib_path, Pathname.new("my_fake_arduino_lib_dir"))
+  cpp_library = ArduinoCI::CppLibrary.new(cpp_lib_path,
+                                          Pathname.new("my_fake_arduino_lib_dir"),
+                                          ["excludeThis"])
   context "cpp_files" do
     it "finds cpp files in directory" do
       testsomething_cpp_files = [Pathname.new("TestSomething/test-something.cpp")]


### PR DESCRIPTION
## Exclude certain directories from exclusion in compilation

* Add exclude_dirs option to [unittest] section in configuration file
* Add a filter in ArduinoCI::CppLibrary to filter out the files in directories specified there
* Adjust unittests to take the new feature into account

## Issues Fixed

* Fixes #29 
