### PR TITLE
Fix/update links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Windows  | [![Windows Build status](https://ci.appveyor.com/api/projects/status/
 |-----------------------------------------------------------------------------|:--:|:---------------:|:--------:|:-------------:|:-------:|:---:|:-----:|:--------|
 |[ArduinoCI](https://github.com/ianfixes/arduino_ci)                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |Free (Apache-2.0)|
 |[ArduinoUnit](https://github.com/mmurdoch/arduinounit)                       | ❌ | ❌ | ⚠️ Hardware-based|❌ | ✅ | ✅ | ✅ |Free (MIT)|
-|[Adafruit `travis-ci-arduino`](https://github.com/adafruit/travis-ci-arduino)| ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |Free (MIT)|
+|[Adafruit `ci-arduino`](https://github.com/adafruit/ci-arduino)| ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |Free (MIT)|
 |[PlatformIO](https://platformio.org)                                         | ✅ | ✅ | ⚠️ Paid only | ❌ | ✅ | ✅ | ✅ |⚠️ EULA|
 |Official [Arduino IDE](https://www.arduino.cc/en/main/software)              | ❌ | ⚠️ Manually | ❌ |N/A 😉| ✅ | ✅ | ✅ |Free (GPLv2)|
 
@@ -167,6 +167,6 @@ This gem was written by Ian Katz (ianfixes@gmail.com) in 2018.  It's released un
 ## See Also
 
 * [Contributing](CONTRIBUTING.md)
-* [Adafruit/travis-ci-arduino](https://github.com/adafruit/travis-ci-arduino) which inspired this project
+* [Adafruit/ci-arduino](https://github.com/adafruit/ci-arduino) which inspired this project
 * [mmurdoch/arduinounit](https://github.com/mmurdoch/arduinounit) from which the unit test macros were adopted
 

--- a/SampleProjects/DoSomething/README.md
+++ b/SampleProjects/DoSomething/README.md
@@ -41,7 +41,7 @@ This will install the necessary ruby gem, and run it.  There are no command line
 
 ### `.arduino-ci.yaml` ArduinoCI configuration
 
-This file controls all aspects of building and unit testing.  The (relatively-complete) defaults can be found [in the base project](../../misc/default.yaml).
+This file controls all aspects of building and unit testing.  The (relatively-complete) defaults can be found [in the base project](../../misc/default.yml).
 
 The most relevant sections for most projects will be as follows:
 


### PR DESCRIPTION
Link to misc/default.yaml was broken by a [change to the file extension](https://github.com/ianfixes/arduino_ci/commit/70b883debb3d9a6311c7155c560fd18bab9162f9#diff-bdcd14c15cb926f2dba0d1d295bf3c65).

While I was fixing that link, I thought I should do a review of the other links in the documentation. The adafruit/travis-ci-arduino repository has been renamed to adafruit/ci-arduino (to reflect the change of focus to GitHub Actions). GitHub sets up a redirect, so this wasn't actually causing a problem, but I thought I'd go ahead and update the links since I was looking at it.