### PR TITLE
Explicitly exclude sample projects from Rubocop tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,8 +4,7 @@ AllCops:
     - 'spec/*.rb'
     - '**/generated_parser/*'
     - './vendor/**/*'
-
-# inherit_from: .rubocop_todo.yml
+    - 'SampleProjects/**/vendor/**/*'
 
 # TODO: stuff I actually want to fix
 Style/RescueStandardError:


### PR DESCRIPTION
Running a `bundle install` locally in one of the sample projects can leave behind a vendor bundle that the top-level Rubocop will try to inspect.

This explicitly ignores those.

## Issues Fixed

* Fixes #152
