### PR TITLE
Provide for local Projects directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Gemfile.lock
 /coverage/
 /doc/
 /pkg/
+/Projects/
 /spec/reports/
 vendor
 *.gem

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Windows  | [![Windows Build status](https://ci.appveyor.com/api/projects/status/
 
 ## Quick Start
 
+Create a project in (or copy your project to) the Projects directory. 
+
 For a bare-bones example that you can copy from, see [SampleProjects/DoSomething](SampleProjects/DoSomething).
 
 The complete set of C++ unit tests for the `arduino_ci` library itself are in the [SampleProjects/TestSomething](SampleProjects/TestSomething) project.  The [test files](SampleProjects/TestSomething/test/) are named after the type of feature being tested.
@@ -82,10 +84,11 @@ vendor
 
 ### Installing the Dependencies
 
-Fulfilling the `arduino_ci` library dependency is as easy as running this command:
+Fulfilling the `arduino_ci` library dependency is as easy as running either of these two commands:
 
 ```
-$ bundle install
+$ bundle install   # adds packages to global library (may require admin rights)
+$ bundle install --path vendor/bundle   # adds packages to local library
 ```
 
 


### PR DESCRIPTION
My reading of the docs leads me to believe that the typical usage is to create projects in `/SampleProjects/`. Doing so causes my checkout of the `arduino_ci` project to show changes. I suggest that we guide users to put their own projects in a `./Projects/` directory that is ignored by the `arduino_ci` project. To that end this PR adds that directory to the `.gitignore` file.

Also, I've found that `bundle install` doesn't work for me on macOS 10.15.6 since macOS tries to protect the global library. This PR also adds an alternate install script that places packages in the local directory.
